### PR TITLE
Supports bindings created from k8s config maps & secrets

### DIFF
--- a/internal/config_map.go
+++ b/internal/config_map.go
@@ -19,6 +19,7 @@ package internal
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -35,6 +36,15 @@ func NewConfigMapFromPath(path string) (ConfigMap, error) {
 
 	configMap := ConfigMap{}
 	for _, file := range files {
+		if strings.HasPrefix(filepath.Base(file), ".") {
+			//ignore hidden files
+			continue
+		}
+		if stat, err := os.Stat(file); err != nil {
+			return nil, fmt.Errorf("failed to stat file %s\n%w", file, err)
+		} else if stat.IsDir() {
+			continue
+		}
 		contents, err := ioutil.ReadFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read file %s\n%w", file, err)

--- a/internal/environment_writer_test.go
+++ b/internal/environment_writer_test.go
@@ -71,4 +71,3 @@ func testEnvironmentWriter(t *testing.T, context spec.G, it spec.S) {
 		Expect(path).NotTo(BeAnExistingFile())
 	})
 }
-

--- a/platform.go
+++ b/platform.go
@@ -46,7 +46,7 @@ type Binding struct {
 	Secret map[string]string
 
 	// Path is the path to the binding directory.
-	Path   string
+	Path string
 }
 
 // NewBinding creates a new Binding initialized with no metadata or secret.
@@ -75,10 +75,10 @@ func NewBindingFromPath(path string) (Binding, error) {
 	}
 
 	return Binding{
-		Name: filepath.Base(path),
-		Path: path,
+		Name:     filepath.Base(path),
+		Path:     path,
 		Metadata: metadata,
-		Secret: secret,
+		Secret:   secret,
 	}, nil
 }
 


### PR DESCRIPTION
When binding metadata or secrets are created using Kubernetes ConfigMaps or Kubernetes secrets, respectively, the key files are symlinks to data files in a hidden directory.

a simplified example binding:
```
├── metadata
│   ├── .hidden
│   │   └── test-metadata-key
│   └── test-metadata-key -> .hidden/test-metadata-key
└── secret
    ├── .hidden
    │   └── test-secret-key
    └── test-secret-key -> .hidden/test-secret-key
```

Therefore, when parsings binding we should not fail on the existence of directories in the metadata & secret dirs.

* also go fmt

Signed-off-by: Emily Casey <ecasey@pivotal.io>