### PR TITLE
Call exitHandler.Pass() when passing detection

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -166,4 +166,6 @@ func Detect(detector Detector, options ...Option) {
 			return
 		}
 	}
+
+	config.exitHandler.Pass()
 }


### PR DESCRIPTION
This calls `exitHandler.Pass()` when passing detection.