### PR TITLE
Remove Dependabot Commit Message Customization

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
       directory: /
       schedule:
         interval: daily
-      commit-message:
-        include: scope
       labels:
         - 'semver: patch'
         - 'type: dependency-upgrade'
@@ -13,8 +11,6 @@ updates:
       directory: /
       schedule:
         interval: daily
-      commit-message:
-        include: scope
       labels:
         - 'semver: patch'
         - 'type: dependency-upgrade'


### PR DESCRIPTION
This change removes Dependabot's commit message customizations.  They aren't necessary.
