### PR TITLE
Remove BurntSushi

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -18,11 +18,12 @@ package libcnb
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 
 	"github.com/buildpacks/libcnb/internal"
 	"github.com/buildpacks/libcnb/poet"
@@ -108,7 +109,12 @@ func Detect(detector Detector, options ...Option) {
 	}
 
 	file = filepath.Join(ctx.Buildpack.Path, "buildpack.toml")
-	if _, err = toml.DecodeFile(file, &ctx.Buildpack); err != nil && !os.IsNotExist(err) {
+	b, err := ioutil.ReadFile(file)
+	if err != nil && !os.IsNotExist(err) {
+		config.exitHandler.Error(fmt.Errorf("unable to read %s\n%w", file, err))
+		return
+	}
+	if err := toml.Unmarshal(b, &ctx.Buildpack); err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to decode buildpack %s\n%w", file, err))
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/buildpacks/libcnb
 go 1.15
 
 require (
-	github.com/BurntSushi/toml v0.3.1
 	github.com/onsi/gomega v1.10.3
+	github.com/pelletier/go-toml v1.8.1
 	github.com/sclevine/spec v1.4.0
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
-github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -25,6 +24,8 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
@@ -47,7 +48,6 @@ golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/match_toml.go
+++ b/internal/match_toml.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/BurntSushi/toml"
 	"github.com/onsi/gomega/types"
+	"github.com/pelletier/go-toml"
 )
 
 func MatchTOML(expected interface{}) types.GomegaMatcher {
@@ -35,35 +35,33 @@ type matchTOML struct {
 }
 
 func (matcher *matchTOML) Match(actual interface{}) (success bool, err error) {
-	var e, a string
+	var e, a []byte
 
 	switch eType := matcher.expected.(type) {
 	case string:
-		e = eType
+		e = []byte(eType)
 	case []byte:
-		e = string(eType)
+		e = eType
 	default:
 		return false, fmt.Errorf("expected value must be []byte or string, received %T", matcher.expected)
 	}
 
 	switch aType := actual.(type) {
 	case string:
-		a = aType
+		a = []byte(aType)
 	case []byte:
-		a = string(aType)
+		a = aType
 	default:
 		return false, fmt.Errorf("actual value must be []byte or string, received %T", matcher.expected)
 	}
 
 	var eValue map[string]interface{}
-	_, err = toml.Decode(e, &eValue)
-	if err != nil {
+	if err := toml.Unmarshal(e, &eValue); err != nil {
 		return false, err
 	}
 
 	var aValue map[string]interface{}
-	_, err = toml.Decode(a, &aValue)
-	if err != nil {
+	if err := toml.Unmarshal(a, &aValue); err != nil {
 		return false, err
 	}
 

--- a/internal/toml_writer.go
+++ b/internal/toml_writer.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 )
 
 // TOMLWriter is a type used to write TOML files to the filesystem.


### PR DESCRIPTION
Previously, this project used the BurntSushi TOML library.  This library is now unmaintained and shouldn't be used for long term projects.  This change migrates the project onto an alternative TOML library.