### PR TITLE
Implement Buildpack API 0.5

### DIFF
--- a/application.go
+++ b/application.go
@@ -56,8 +56,8 @@ type Slice struct {
 	Paths []string `toml:"paths"`
 }
 
-// Launch represents the contents of launch.toml.
-type Launch struct {
+// LaunchTOML represents the contents of launch.toml.
+type LaunchTOML struct {
 
 	// Labels is the collection of image labels contributed by the buildpack.
 	Labels []Label `toml:"labels"`
@@ -67,6 +67,44 @@ type Launch struct {
 
 	// Slices is the collection of slices contributed by the buildpack.
 	Slices []Slice `toml:"slices"`
+
+	// BOM is a collection of entries for the bill of materials.
+	BOM []BOMEntry `toml:"bom"`
+}
+
+func (l LaunchTOML) isEmpty() bool {
+	return len(l.Labels) == 0 && len(l.Processes) == 0 && len(l.Slices) == 0 && len(l.BOM) == 0
+}
+
+// BuildTOML represents the contents of build.toml.
+type BuildTOML struct {
+	// BOM contains the build-time bill of materials.
+	BOM []BOMEntry `toml:"bom"`
+
+	// Unmet is a collection of buildpack plan entries that should be passed through to subsequent providers.
+	Unmet []UnmetPlanEntry
+}
+
+func (b BuildTOML) isEmpty() bool {
+	return len(b.Unmet) == 0
+}
+
+// BOMEntry contains a bill of materials entry.
+type BOMEntry struct {
+	// Name represents the name of the entry.
+	Name string `toml:"name"`
+
+	// Metadata is the metadata of the entry.  Optional.
+	Metadata map[string]interface{} `toml:"metadata,omitempty"`
+
+	// Launch indicates whether the given entry is included in app image. If launch is true the entry
+	// will be added to the app image Bill of Materials. Launch should be true if the entry describes
+	// the contents of a launch layer or app layer.
+	Launch bool `toml:"-"`
+
+	// Build indicates whether the given entry is available at build time. If build is true the entry
+	// will be added to the build Bill of Materials.
+	Build bool `toml:"-"`
 }
 
 // Store represents the contents of store.toml

--- a/buildpack.go
+++ b/buildpack.go
@@ -69,9 +69,6 @@ type Buildpack struct {
 	// Info is information about the buildpack.
 	Info BuildpackInfo `toml:"buildpack"`
 
-	// Orders is buildpack collection of order definitions in the buildpack.
-	Orders []BuildpackOrder `toml:"order"`
-
 	// Path is the path to the buildpack.
 	Path string
 

--- a/buildpack_plan.go
+++ b/buildpack_plan.go
@@ -16,6 +16,13 @@
 
 package libcnb
 
+// BuildpackPlan represents a buildpack plan.
+type BuildpackPlan struct {
+
+	// Entries represents all the buildpack plan entries.
+	Entries []BuildpackPlanEntry `toml:"entries,omitempty"`
+}
+
 // BuildpackPlanEntry represents an entry in the buildpack plan.
 type BuildpackPlanEntry struct {
 	// Name represents the name of the entry.
@@ -25,9 +32,10 @@ type BuildpackPlanEntry struct {
 	Metadata map[string]interface{} `toml:"metadata,omitempty"`
 }
 
-// BuildpackPlan represents a buildpack plan.
-type BuildpackPlan struct {
-
-	// Entries represents all the buildpack plan entries.
-	Entries []BuildpackPlanEntry `toml:"entries,omitempty"`
+// UnmetPlanEntry denotes an unmet buildpack plan entry. When a buildpack returns an UnmetPlanEntry
+// in the BuildResult, any BuildpackPlanEntry with a matching Name will be provided to subsequent
+// providers.
+type UnmetPlanEntry struct {
+	// Name represents the name of the entry.
+	Name string `toml:"name"`
 }

--- a/detect.go
+++ b/detect.go
@@ -17,6 +17,7 @@
 package libcnb
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -113,6 +114,11 @@ func Detect(detector Detector, options ...Option) {
 		return
 	}
 	logger.Debugf("Buildpack: %+v", ctx.Buildpack)
+
+	if strings.TrimSpace(ctx.Buildpack.API) != "0.5" {
+		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack API 0.5"))
+		return
+	}
 
 	ctx.Platform.Path = config.arguments[1]
 	if logger.IsDebugEnabled() {

--- a/layer.go
+++ b/layer.go
@@ -69,14 +69,8 @@ func (p Profile) ProcessAddf(processType string, name string, format string, a .
 // Contribute represents a layer managed by the buildpack.
 type Layer struct {
 
-	// Build indicates that a layer should be used for builds.
-	Build bool `toml:"build"`
-
-	// Cache indicates that a layer should be cached.
-	Cache bool `toml:"cache"`
-
-	// Launch indicates that a layer should be used for launch.
-	Launch bool `toml:"launch"`
+	// LayerTypes indicates the type of layer
+	LayerTypes
 
 	// Metadata is the metadata associated with the layer.
 	Metadata map[string]interface{} `toml:"metadata"`
@@ -101,6 +95,19 @@ type Layer struct {
 
 	// Exec is the exec.d executables set in the layer.
 	Exec Exec `toml:"-"`
+}
+
+// LayerTypes describes which types apply to a given layer. A layer may have any combination of Launch, Build, and
+// Cache types.
+type LayerTypes struct {
+	// Build indicates that a layer should be used for builds.
+	Build bool `toml:"build"`
+
+	// Cache indicates that a layer should be cached.
+	Cache bool `toml:"cache"`
+
+	// Launch indicates that a layer should be used for launch.
+	Launch bool `toml:"launch"`
 }
 
 //go:generate mockery -name LayerContributor -case=underscore

--- a/layer_test.go
+++ b/layer_test.go
@@ -99,9 +99,9 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			l, err := layers.Layer("test-name")
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(l.Build).To(BeFalse())
-			Expect(l.Cache).To(BeFalse())
-			Expect(l.Launch).To(BeFalse())
+			Expect(l.LayerTypes.Build).To(BeFalse())
+			Expect(l.LayerTypes.Cache).To(BeFalse())
+			Expect(l.LayerTypes.Launch).To(BeFalse())
 			Expect(l.Metadata).To(BeNil())
 			Expect(l.Name).To(Equal("test-name"))
 			Expect(l.Path).To(Equal(filepath.Join(path, "test-name")))

--- a/main_test.go
+++ b/main_test.go
@@ -65,7 +65,7 @@ func testMain(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 			[]byte(`
-api = "0.0.0"
+api = "0.5"
 
 [buildpack]
 id = "test-id"

--- a/platform.go
+++ b/platform.go
@@ -66,7 +66,7 @@ func NewBinding(name string, path string, secret map[string]string) Binding {
 
 	for k, v := range secret {
 		switch k {
-		case BindingType, BindingKind:  // TODO: Remove as CNB_BINDINGS ages out
+		case BindingType, BindingKind: // TODO: Remove as CNB_BINDINGS ages out
 			b.Type = strings.TrimSpace(v)
 		case BindingProvider:
 			b.Provider = strings.TrimSpace(v)


### PR DESCRIPTION
* Writes BOM entries to launch.toml
* Writes Build BOM entries to build.toml
* Writes unmet plan entries to build.toml
* Does not modify buildpack plan

Signed-off-by: Emily Casey <ecasey@vmware.com>