### PR TITLE
Implement Buildpack API 0.6

### DIFF
--- a/application.go
+++ b/application.go
@@ -47,6 +47,10 @@ type Process struct {
 
 	// Command is exec'd directly by the os (no profile.d scripts run)
 	Direct bool `toml:"direct,omitempty"`
+
+	// Default can be set to true to indicate that the process
+	// type being defined should be the default process type for the app image.
+	Default bool `toml:"default,omitempty"`
 }
 
 // Slice represents metadata about a slice.

--- a/build.go
+++ b/build.go
@@ -165,8 +165,8 @@ func Build(builder Builder, options ...Option) {
 	}
 	logger.Debugf("Buildpack: %+v", ctx.Buildpack)
 
-	if strings.TrimSpace(ctx.Buildpack.API) != "0.5" {
-		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack API 0.5"))
+	if strings.TrimSpace(ctx.Buildpack.API) != "0.6" {
+		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack API 0.6"))
 		return
 	}
 

--- a/build_test.go
+++ b/build_test.go
@@ -66,13 +66,23 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 			[]byte(`
-api = "0.5"
+api = "0.6"
 
 [buildpack]
 id = "test-id"
 name = "test-name"
 version = "1.1.1"
 clear-env = true
+description = "A test buildpack"
+keywords = ["test", "buildpack"]
+
+[[buildpack.licenses]]
+type = "Apache-2.0"
+uri = "https://spdx.org/licenses/Apache-2.0.html"
+
+[[buildpack.licenses]]
+type = "Apache-1.1"
+uri = "https://spdx.org/licenses/Apache-1.1.html"
 
 [[order]]
 [[order.group]]
@@ -161,11 +171,11 @@ test-key = "test-value"
 		Expect(os.RemoveAll(platformPath)).To(Succeed())
 	})
 
-	context("buildpack API is not 0.5", func() {
+	context("buildpack API is not 0.6", func() {
 		it.Before(func() {
 			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 				[]byte(`
-api = "0.4"
+api = "0.5"
 
 [buildpack]
 id = "test-id"
@@ -183,7 +193,7 @@ version = "1.1.1"
 			)
 
 			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(
-				"this version of libcnb is only compatible with buildpack API 0.5",
+				"this version of libcnb is only compatible with buildpack API 0.6",
 			))
 		})
 	})
@@ -221,12 +231,18 @@ version = "1.1.1"
 		ctx := builder.Calls[0].Arguments[0].(libcnb.BuildContext)
 		Expect(ctx.Application).To(Equal(libcnb.Application{Path: applicationPath}))
 		Expect(ctx.Buildpack).To(Equal(libcnb.Buildpack{
-			API: "0.5",
+			API: "0.6",
 			Info: libcnb.BuildpackInfo{
 				ID:               "test-id",
 				Name:             "test-name",
 				Version:          "1.1.1",
 				ClearEnvironment: true,
+				Description:      "A test buildpack",
+				Keywords:         []string{"test", "buildpack"},
+				Licenses: []libcnb.License{
+					{Type: "Apache-2.0", URI: "https://spdx.org/licenses/Apache-2.0.html"},
+					{Type: "Apache-1.1", URI: "https://spdx.org/licenses/Apache-1.1.html"},
+				},
 			},
 			Path: buildpackPath,
 			Stacks: []libcnb.BuildpackStack{
@@ -427,6 +443,7 @@ version = "1.1.1"
 				{
 					Type:    "test-type",
 					Command: "test-command",
+					Default: true,
 				},
 			},
 			Slices: []libcnb.Slice{
@@ -453,6 +470,7 @@ version = "1.1.1"
 				{
 					Type:    "test-type",
 					Command: "test-command",
+					Default: true,
 				},
 			},
 			Slices: []libcnb.Slice{

--- a/buildpack.go
+++ b/buildpack.go
@@ -32,6 +32,27 @@ type BuildpackInfo struct {
 
 	// ClearEnvironment is whether the environment should be clear of user-configured environment variables.
 	ClearEnvironment bool `toml:"clear-env"`
+
+	// Description is a string describing the buildpack.
+	Description string `toml:"description"`
+
+	// Keywords is a list of words that are associated with the buildpack.
+	Keywords []string `toml:"keywords"`
+
+	// Licenses a list of buildpack licenses.
+	Licenses []License `toml:"licenses"`
+}
+
+// License contains information about a Software License
+// governing the use or redistribution of a buildpack
+type License struct {
+	// Type is the identifier for the license.
+	// It MAY use the SPDX 2.1 license expression, but is not limited to identifiers in the SPDX Licenses List.
+	Type string `toml:"type"`
+
+	// URI may be specified in lieu of or in addition to type to point to the license
+	// if this buildpack is using a nonstandard license.
+	URI string `toml:"uri"`
 }
 
 // BuildpackOrderBuildpack is a buildpack within in a buildpack order group.

--- a/detect.go
+++ b/detect.go
@@ -115,8 +115,8 @@ func Detect(detector Detector, options ...Option) {
 	}
 	logger.Debugf("Buildpack: %+v", ctx.Buildpack)
 
-	if strings.TrimSpace(ctx.Buildpack.API) != "0.5" {
-		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack API 0.5"))
+	if strings.TrimSpace(ctx.Buildpack.API) != "0.6" {
+		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack API 0.6"))
 		return
 	}
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -61,13 +61,23 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 			[]byte(`
-api = "0.5"
+api = "0.6"
 
 [buildpack]
 id = "test-id"
 name = "test-name"
 version = "1.1.1"
 clear-env = true
+description = "A test buildpack"
+keywords = ["test", "buildpack"]
+
+[[buildpack.licenses]]
+type = "Apache-2.0"
+uri = "https://spdx.org/licenses/Apache-2.0.html"
+
+[[buildpack.licenses]]
+type = "Apache-1.1"
+uri = "https://spdx.org/licenses/Apache-1.1.html"
 
 [[stacks]]
 id = "test-id"
@@ -125,7 +135,7 @@ test-key = "test-value"
 		Expect(os.RemoveAll(platformPath)).To(Succeed())
 	})
 
-	context("buildpack API is not 0.5", func() {
+	context("buildpack API is not 0.6", func() {
 		it.Before(func() {
 			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 				[]byte(`
@@ -147,7 +157,7 @@ version = "1.1.1"
 			)
 
 			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(
-				"this version of libcnb is only compatible with buildpack API 0.5",
+				"this version of libcnb is only compatible with buildpack API 0.6",
 			))
 		})
 	})
@@ -186,12 +196,18 @@ version = "1.1.1"
 		ctx := detector.Calls[0].Arguments[0].(libcnb.DetectContext)
 		Expect(ctx.Application).To(Equal(libcnb.Application{Path: applicationPath}))
 		Expect(ctx.Buildpack).To(Equal(libcnb.Buildpack{
-			API: "0.5",
+			API: "0.6",
 			Info: libcnb.BuildpackInfo{
 				ID:               "test-id",
 				Name:             "test-name",
 				Version:          "1.1.1",
 				ClearEnvironment: true,
+				Description:      "A test buildpack",
+				Keywords:         []string{"test", "buildpack"},
+				Licenses: []libcnb.License{
+					{Type: "Apache-2.0", URI: "https://spdx.org/licenses/Apache-2.0.html"},
+					{Type: "Apache-1.1", URI: "https://spdx.org/licenses/Apache-1.1.html"},
+				},
 			},
 			Path: buildpackPath,
 			Stacks: []libcnb.BuildpackStack{

--- a/layer.go
+++ b/layer.go
@@ -70,7 +70,7 @@ func (p Profile) ProcessAddf(processType string, name string, format string, a .
 type Layer struct {
 
 	// LayerTypes indicates the type of layer
-	LayerTypes
+	LayerTypes `toml:"types"`
 
 	// Metadata is the metadata associated with the layer.
 	Metadata map[string]interface{} `toml:"metadata"`

--- a/layer_test.go
+++ b/layer_test.go
@@ -115,6 +115,10 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			Expect(ioutil.WriteFile(
 				filepath.Join(path, "test-name.toml"),
 				[]byte(`
+[types]
+launch = true
+build = false
+
 [metadata]
 test-key = "test-value"
 		`),
@@ -125,6 +129,8 @@ test-key = "test-value"
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(l.Metadata).To(Equal(map[string]interface{}{"test-key": "test-value"}))
+			Expect(l.Launch).To(BeTrue())
+			Expect(l.Build).To(BeFalse())
 		})
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -65,7 +65,7 @@ func testMain(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 			[]byte(`
-api = "0.5"
+api = "0.6"
 
 [buildpack]
 id = "test-id"


### PR DESCRIPTION
This commit adds support for -

- Buildpacks may contribute the default process type
- Adds new descriptor keys to buildpack.toml
- Adds types table to <layers>/<layer>.toml

BP Spec 0.6 - https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.6

Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>