### PR TITLE
Modifications to enable libcnb to be compatible with both versions 0.5 and 0.6 of the API

### DIFF
--- a/build.go
+++ b/build.go
@@ -325,6 +325,15 @@ func Build(builder Builder, options ...Option) {
 	if !launch.isEmpty() {
 		file = filepath.Join(ctx.Layers.Path, "launch.toml")
 		logger.Debugf("Writing application metadata: %s <= %+v", file, launch)
+
+		if API == "0.5" {
+			for _, process := range launch.Processes {
+				if process.Default {
+					logger.Info("WARNING: Launch layer is setting default=true, but that is not supported until API version 0.6. This setting will be ignored.")
+				}
+			}
+		}
+
 		if err = config.tomlWriter.Write(file, launch); err != nil {
 			config.exitHandler.Error(fmt.Errorf("unable to write application metadata %s\n%w", file, err))
 			return

--- a/build.go
+++ b/build.go
@@ -167,7 +167,7 @@ func Build(builder Builder, options ...Option) {
 
 	API := strings.TrimSpace(ctx.Buildpack.API)
 	if API != "0.5" && API != "0.6" {
-		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack API 0.5 and 0.6"))
+		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack APIs 0.5 and 0.6"))
 		return
 	}
 

--- a/detect.go
+++ b/detect.go
@@ -115,8 +115,9 @@ func Detect(detector Detector, options ...Option) {
 	}
 	logger.Debugf("Buildpack: %+v", ctx.Buildpack)
 
-	if strings.TrimSpace(ctx.Buildpack.API) != "0.6" {
-		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack API 0.6"))
+	API := strings.TrimSpace(ctx.Buildpack.API)
+	if API != "0.5" && API != "0.6" {
+		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack API 0.5 and 0.6"))
 		return
 	}
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -135,7 +135,7 @@ test-key = "test-value"
 		Expect(os.RemoveAll(platformPath)).To(Succeed())
 	})
 
-	context("buildpack API is not 0.6", func() {
+	context("buildpack API is not 0.5 or 0.6", func() {
 		it.Before(func() {
 			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 				[]byte(`
@@ -157,7 +157,7 @@ version = "1.1.1"
 			)
 
 			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(
-				"this version of libcnb is only compatible with buildpack API 0.6",
+				"this version of libcnb is only compatible with buildpack API 0.5 and 0.6",
 			))
 		})
 	})

--- a/internal/layer_api_5.go
+++ b/internal/layer_api_5.go
@@ -1,0 +1,16 @@
+package internal
+
+// LayerAPI5 is used for backwards compatibility with serialization/deserialization of the layer toml
+type LayerAPI5 struct {
+	// Build indicates that a layer should be used for builds.
+	Build bool `toml:"build"`
+
+	// Cache indicates that a layer should be cached.
+	Cache bool `toml:"cache"`
+
+	// Launch indicates that a layer should be used for launch.
+	Launch bool `toml:"launch"`
+
+	// Metadata is the metadata associated with the layer.
+	Metadata map[string]interface{} `toml:"metadata"`
+}

--- a/internal/layer_api_5.go
+++ b/internal/layer_api_5.go
@@ -2,6 +2,8 @@ package internal
 
 // LayerAPI5 is used for backwards compatibility with serialization/deserialization of the layer toml
 type LayerAPI5 struct {
+	// bool's are inlined to instead of using libcnb.LayerTypes to break a circular package reference, internal -> libcnb -> internal -> ...
+
 	// Build indicates that a layer should be used for builds.
 	Build bool `toml:"build"`
 

--- a/layer.go
+++ b/layer.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
+	"github.com/buildpacks/libcnb/internal"
 )
 
 // Exec represents the exec.d layer location
@@ -144,6 +145,18 @@ func (l *Layers) Layer(name string) (Layer, error) {
 	f := filepath.Join(l.Path, fmt.Sprintf("%s.toml", name))
 	if _, err := toml.DecodeFile(f, &layer); err != nil && !os.IsNotExist(err) {
 		return Layer{}, fmt.Errorf("unable to decode layer metadata %s\n%w", f, err)
+	}
+
+	if !layer.Build && !layer.Cache && !layer.Launch {
+		// if all three are false, that could mean we have a API <= 0.5 TOML file
+		// try parsing the <= 0.5 API format where these were top level attributes
+		buf := internal.LayerAPI5{}
+		if _, err := toml.DecodeFile(f, &buf); err != nil && !os.IsNotExist(err) {
+			return Layer{}, fmt.Errorf("unable to decode layer metadata %s\n%w", f, err)
+		}
+		layer.Build = buf.Build
+		layer.Cache = buf.Cache
+		layer.Launch = buf.Launch
 	}
 
 	return layer, nil

--- a/layer_test.go
+++ b/layer_test.go
@@ -111,7 +111,28 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			Expect(l.Profile).To(Equal(libcnb.Profile{}))
 		})
 
-		it("reads existing metadata", func() {
+		it("reads existing 0.5 metadata", func() {
+			Expect(ioutil.WriteFile(
+				filepath.Join(path, "test-name.toml"),
+				[]byte(`
+launch = true
+build = false
+
+[metadata]
+test-key = "test-value"
+		`),
+				0644),
+			).To(Succeed())
+
+			l, err := layers.Layer("test-name")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(l.Metadata).To(Equal(map[string]interface{}{"test-key": "test-value"}))
+			Expect(l.Launch).To(BeTrue())
+			Expect(l.Build).To(BeFalse())
+		})
+
+		it("reads existing 0.6 metadata", func() {
 			Expect(ioutil.WriteFile(
 				filepath.Join(path, "test-name.toml"),
 				[]byte(`
@@ -131,6 +152,30 @@ test-key = "test-value"
 			Expect(l.Metadata).To(Equal(map[string]interface{}{"test-key": "test-value"}))
 			Expect(l.Launch).To(BeTrue())
 			Expect(l.Build).To(BeFalse())
+		})
+
+		it("reads existing 0.6 metadata with launch, build and cache all false", func() {
+			Expect(ioutil.WriteFile(
+				filepath.Join(path, "test-name.toml"),
+				[]byte(`
+[types]
+launch = false
+build = false
+cache = false
+
+[metadata]
+test-key = "test-value"
+		`),
+				0644),
+			).To(Succeed())
+
+			l, err := layers.Layer("test-name")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(l.Metadata).To(Equal(map[string]interface{}{"test-key": "test-value"}))
+			Expect(l.Launch).To(BeFalse())
+			Expect(l.Build).To(BeFalse())
+			Expect(l.Cache).To(BeFalse())
 		})
 	})
 }


### PR DESCRIPTION
At the moment, the latest version of libcnb (1.20.0) breaks compatibility for buildpacks that are still on the 0.5 version of the API. This patch creates compatibility for both 0.5 and 0.6.

The use case for this change is upgrading buildpacks. On the Paketo team, we have quite a few buildpacks that are using libpak and libcnb. This abrupt change means we either have to hold back libcnb updates or we have to go through and update all of the buildpacks to use the new API. Having compatibility for both version 0.5 and 0.6 eases the transition as we can keep updating libcnb and migrate buildpacks to 0.6 at a more leisurely pace.

My suggestion would be to remove this 0.5 compatibility layer when we add support for the 0.7 (or whatever's next) API version. That way we're supporting the latest two API versions at any given moment, again helping buildpack authors to transition more easily.