### PR TITLE
Add support for k8s service bindings during build time

### DIFF
--- a/build.go
+++ b/build.go
@@ -179,9 +179,8 @@ func Build(builder Builder, options ...Option) {
 		logger.Debug(PlatformFormatter(ctx.Platform))
 	}
 
-	file = filepath.Join(ctx.Platform.Path, "bindings")
-	if ctx.Platform.Bindings, err = NewBindingsFromEnvOrPath(file); err != nil {
-		config.exitHandler.Error(fmt.Errorf("unable to read platform bindings %s\n%w", file, err))
+	if ctx.Platform.Bindings, err = NewBindingsForBuild(ctx.Platform.Path); err != nil {
+		config.exitHandler.Error(fmt.Errorf("unable to read platform bindings %s\n%w", ctx.Platform.Path, err))
 		return
 	}
 	logger.Debugf("Platform Bindings: %+v", ctx.Platform.Bindings)

--- a/build.go
+++ b/build.go
@@ -180,7 +180,7 @@ func Build(builder Builder, options ...Option) {
 	}
 
 	file = filepath.Join(ctx.Platform.Path, "bindings")
-	if ctx.Platform.Bindings, err = NewBindingsFromPath(file); err != nil {
+	if ctx.Platform.Bindings, err = NewBindingsFromEnvOrPath(file); err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to read platform bindings %s\n%w", file, err))
 		return
 	}

--- a/platform.go
+++ b/platform.go
@@ -167,6 +167,21 @@ func NewBindingsFromPath(path string) (Bindings, error) {
 	return bindings, nil
 }
 
+// NewBindingsFromEnvOrPath creates a new bindings from all the bindings at the path defined by $SERVICE_BINDING_ROOT
+// or $CNB_BINDINGS if it does not exist.  If neither is defined, it defaults to using the given path.
+func NewBindingsFromEnvOrPath(path string) (Bindings, error) {
+	if path, ok := os.LookupEnv("SERVICE_BINDING_ROOT"); ok {
+		return NewBindingsFromPath(path)
+	}
+
+	// TODO: Remove as CNB_BINDINGS ages out
+	if path, ok := os.LookupEnv("CNB_BINDINGS"); ok {
+		return NewBindingsFromPath(path)
+	}
+
+	return NewBindingsFromPath(path)
+}
+
 // Platform is the contents of the platform directory.
 type Platform struct {
 

--- a/platform_test.go
+++ b/platform_test.go
@@ -304,6 +304,96 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 					}))
 				})
 			})
+
+			context("from environment or path", func() {
+				context("when SERVICE_BINDING_ROOT is defined but CNB_BINDINGS or the passed path does not exist", func() {
+					it.Before(func() {
+						Expect(os.Setenv("SERVICE_BINDING_ROOT", path))
+						Expect(os.Setenv("CNB_BINDINGS", "does not exist"))
+					})
+
+					it.After(func() {
+						Expect(os.Unsetenv("SERVICE_BINDING_ROOT"))
+						Expect(os.Unsetenv("CNB_BINDINGS"))
+					})
+
+					it("creates bindings from path in SERVICE_BINDING_ROOT", func() {
+						Expect(libcnb.NewBindingsFromEnvOrPath("random-path-that-does-not-exist")).To(Equal(libcnb.Bindings{
+							libcnb.Binding{
+								Name:     "alpha",
+								Path:     filepath.Join(path, "alpha"),
+								Type:     "test-type",
+								Provider: "test-provider",
+								Secret:   map[string]string{"test-secret-key": "test-secret-value"},
+							},
+							libcnb.Binding{
+								Name:     "bravo",
+								Path:     filepath.Join(path, "bravo"),
+								Type:     "test-type",
+								Provider: "test-provider",
+								Secret:   map[string]string{"test-secret-key": "test-secret-value"},
+							},
+						}))
+					})
+				})
+
+				context("when CNB_BINDINGS is defined but the path does not exist", func() {
+					it.Before(func() {
+						Expect(os.Setenv("CNB_BINDINGS", path))
+					})
+
+					it.After(func() {
+						Expect(os.Unsetenv("CNB_BINDINGS"))
+					})
+
+					it("creates bindings from path in CNB_BINDINGS", func() {
+						Expect(libcnb.NewBindingsFromEnvOrPath("random-path-that-does-not-exist")).To(Equal(libcnb.Bindings{
+							libcnb.Binding{
+								Name:     "alpha",
+								Path:     filepath.Join(path, "alpha"),
+								Type:     "test-type",
+								Provider: "test-provider",
+								Secret:   map[string]string{"test-secret-key": "test-secret-value"},
+							},
+							libcnb.Binding{
+								Name:     "bravo",
+								Path:     filepath.Join(path, "bravo"),
+								Type:     "test-type",
+								Provider: "test-provider",
+								Secret:   map[string]string{"test-secret-key": "test-secret-value"},
+							},
+						}))
+					})
+				})
+
+				context("when SERVICE_BINDING_ROOT and CNB_BINDINGS is not defined but the path exists", func() {
+					it("creates bindings from the given path", func() {
+						Expect(libcnb.NewBindingsFromEnvOrPath(path)).To(Equal(libcnb.Bindings{
+							libcnb.Binding{
+								Name:     "alpha",
+								Path:     filepath.Join(path, "alpha"),
+								Type:     "test-type",
+								Provider: "test-provider",
+								Secret:   map[string]string{"test-secret-key": "test-secret-value"},
+							},
+							libcnb.Binding{
+								Name:     "bravo",
+								Path:     filepath.Join(path, "bravo"),
+								Type:     "test-type",
+								Provider: "test-provider",
+								Secret:   map[string]string{"test-secret-key": "test-secret-value"},
+							},
+						}))
+					})
+				})
+
+				context("when no valid binding variable is set", func() {
+					it("returns an an empty binding", func() {
+						Expect(libcnb.NewBindingsFromEnvOrPath("does-not-exist")).To(Equal(libcnb.Bindings{}))
+					})
+				})
+
+			})
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>

Fixes #55 

cc: @dmikusa-pivotal 

Maybe blocked on https://github.com/buildpacks/spec/pull/193/files but we already support k8s service bindings during runtime which is currently not defined in the spec.