### PR TITLE
Include BOM in test for emptiness

### DIFF
--- a/application.go
+++ b/application.go
@@ -90,7 +90,7 @@ type BuildTOML struct {
 }
 
 func (b BuildTOML) isEmpty() bool {
-	return len(b.Unmet) == 0
+	return len(b.BOM) == 0 && len(b.Unmet) == 0
 }
 
 // BOMEntry contains a bill of materials entry.


### PR DESCRIPTION
The `BuildTOML.isEmpty()` method is used in one place, build.go, to check if it should write out build.toml. In the present state, if Unmet is empty but you have BOM entries then the build.toml and BOM entries are never written out. This change will look at both BOM & Unmet to determine emptiness. Thus it will write build.toml if BOM or Unmet has values.
