### PR TITLE
Add struct tag to Buildpack.Path field

### DIFF
--- a/buildpack.go
+++ b/buildpack.go
@@ -91,7 +91,7 @@ type Buildpack struct {
 	Info BuildpackInfo `toml:"buildpack"`
 
 	// Path is the path to the buildpack.
-	Path string `toml:"path,omitempty"`
+	Path string `toml:"-"`
 
 	// Stacks is the collection of stacks supported by the buildpack.
 	Stacks []BuildpackStack `toml:"stacks"`

--- a/buildpack.go
+++ b/buildpack.go
@@ -91,7 +91,7 @@ type Buildpack struct {
 	Info BuildpackInfo `toml:"buildpack"`
 
 	// Path is the path to the buildpack.
-	Path string
+	Path string `toml:"path,omitempty"`
 
 	// Stacks is the collection of stacks supported by the buildpack.
 	Stacks []BuildpackStack `toml:"stacks"`

--- a/buildpack_test.go
+++ b/buildpack_test.go
@@ -45,6 +45,6 @@ func testBuildpackTOML(t *testing.T, context spec.G, it spec.S) {
 		output := &bytes.Buffer{}
 
 		Expect(toml.NewEncoder(output).Encode(bp)).To(Succeed())
-		Expect(output.String()).NotTo(ContainSubstring("ath = ")) // match on path and Path
+		Expect(output.String()).NotTo(Or(ContainSubstring("Path = "), ContainSubstring("path = ")))
 	})
 }

--- a/buildpack_test.go
+++ b/buildpack_test.go
@@ -32,22 +32,7 @@ func testBuildpackTOML(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 	)
 
-	it("does not serialize an empty Path field", func() {
-		bp := libcnb.Buildpack{
-			API: "0.6",
-			Info: libcnb.BuildpackInfo{
-				ID:   "test-buildpack/sample",
-				Name: "sample",
-			},
-		}
-
-		output := &bytes.Buffer{}
-
-		Expect(toml.NewEncoder(output).Encode(bp)).To(Succeed())
-		Expect(output.String()).NotTo(ContainSubstring("Path = "))
-	})
-
-	it("serializes a non-empty Path field", func() {
+	it("does not serialize the Path field", func() {
 		bp := libcnb.Buildpack{
 			API: "0.6",
 			Info: libcnb.BuildpackInfo{
@@ -60,6 +45,6 @@ func testBuildpackTOML(t *testing.T, context spec.G, it spec.S) {
 		output := &bytes.Buffer{}
 
 		Expect(toml.NewEncoder(output).Encode(bp)).To(Succeed())
-		Expect(output.String()).To(ContainSubstring(`path = "../buildpack"`))
+		Expect(output.String()).NotTo(ContainSubstring("ath = ")) // match on path and Path
 	})
 }

--- a/buildpack_test.go
+++ b/buildpack_test.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libcnb_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/buildpacks/libcnb"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testBuildpackTOML(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+	)
+
+	it("does not serialize an empty Path field", func() {
+		bp := libcnb.Buildpack{
+			API: "0.6",
+			Info: libcnb.BuildpackInfo{
+				ID:   "test-buildpack/sample",
+				Name: "sample",
+			},
+		}
+
+		output := &bytes.Buffer{}
+
+		Expect(toml.NewEncoder(output).Encode(bp)).To(Succeed())
+		Expect(output.String()).NotTo(ContainSubstring("Path = "))
+	})
+
+	it("serializes a non-empty Path field", func() {
+		bp := libcnb.Buildpack{
+			API: "0.6",
+			Info: libcnb.BuildpackInfo{
+				ID:   "test-buildpack/sample",
+				Name: "sample",
+			},
+			Path: "../buildpack",
+		}
+
+		output := &bytes.Buffer{}
+
+		Expect(toml.NewEncoder(output).Encode(bp)).To(Succeed())
+		Expect(output.String()).To(ContainSubstring(`path = "../buildpack"`))
+	})
+}

--- a/init_test.go
+++ b/init_test.go
@@ -33,5 +33,6 @@ func TestUnit(t *testing.T) {
 	suite("Main", testMain)
 	suite("Platform", testPlatform)
 	suite("ExecD", testExecD)
+	suite("BuildpackTOML", testBuildpackTOML)
 	suite.Run(t)
 }


### PR DESCRIPTION
Most Go applications use `github.com/burntsushi/toml` as their toml parsing library. When struct tags are omitted, the library will do case-insensitive deserialization, so a property called `path` will successfully unmarshal into the `Path` struct field. 

However, if youmarshal a Buildpack instance to toml, the `Path` field appears regardless of whether it is set or not, and technically violates the buildpack toml spec. This PR adds a struct tag to not only marshal the field to the `path` property in the resultant toml, but also adds the `omitempty` modifier to ignore the field altogether when not set.

This resolves #85 

Signed-off-by: Josh Ghiloni <jghiloni@vmware.com>