### PR TITLE
Renames poet -> log

### DIFF
--- a/build.go
+++ b/build.go
@@ -27,7 +27,7 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/buildpacks/libcnb/internal"
-	"github.com/buildpacks/libcnb/poet"
+	"github.com/buildpacks/libcnb/log"
 )
 
 // BuildContext contains the inputs to build.
@@ -132,7 +132,7 @@ func Build(build BuildFunc, options ...Option) {
 		ok   bool
 	)
 	ctx := BuildContext{}
-	logger := poet.NewLogger(os.Stdout)
+	logger := log.New(os.Stdout)
 
 	ctx.Application.Path, err = os.Getwd()
 	if err != nil {

--- a/detect.go
+++ b/detect.go
@@ -26,7 +26,7 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/buildpacks/libcnb/internal"
-	"github.com/buildpacks/libcnb/poet"
+	"github.com/buildpacks/libcnb/log"
 )
 
 // DetectContext contains the inputs to detection.
@@ -84,7 +84,7 @@ func Detect(detect DetectFunc, options ...Option) {
 		ok   bool
 	)
 	ctx := DetectContext{}
-	logger := poet.NewLogger(os.Stdout)
+	logger := log.New(os.Stdout)
 
 	ctx.Application.Path, err = os.Getwd()
 	if err != nil {

--- a/log/init_test.go
+++ b/log/init_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package poet_test
+package log_test
 
 import (
 	"testing"
@@ -24,7 +24,7 @@ import (
 )
 
 func TestUnit(t *testing.T) {
-	suite := spec.New("libcnb/poet", spec.Report(report.Terminal{}))
+	suite := spec.New("libcnb/log", spec.Report(report.Terminal{}))
 	suite("Logger", testLogger)
 	suite.Run(t)
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package poet
+package log
 
 import (
 	"fmt"
@@ -40,8 +40,8 @@ func WithDebug(writer io.Writer) Option {
 	}
 }
 
-// NewLoggerWithOptions create a new instance of Logger.  It configures the Logger with options.
-func NewLoggerWithOptions(writer io.Writer, options ...Option) Logger {
+// NewWithOptions create a new instance of Logger.  It configures the Logger with options.
+func NewWithOptions(writer io.Writer, options ...Option) Logger {
 	l := Logger{
 		info: writer,
 	}
@@ -53,17 +53,17 @@ func NewLoggerWithOptions(writer io.Writer, options ...Option) Logger {
 	return l
 }
 
-// NewLogger creates a new instance of Logger.  It configures debug logging if $BP_DEBUG is set.
-func NewLogger(writer io.Writer) Logger {
+// New creates a new instance of Logger.  It configures debug logging if $BP_DEBUG is set.
+func New(writer io.Writer) Logger {
 	var options []Option
 
 	// check for presence and value of log level environment variable
-	options = LogLevel(options, writer)
+	options = Level(options, writer)
 
-	return NewLoggerWithOptions(writer, options...)
+	return NewWithOptions(writer, options...)
 }
 
-func LogLevel(options []Option, writer io.Writer) []Option {
+func Level(options []Option, writer io.Writer) []Option {
 	// Check for older log level env variable
 	_, dbSet := os.LookupEnv("BP_DEBUG")
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package poet_test
+package log_test
 
 import (
 	"bytes"
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 
-	"github.com/buildpacks/libcnb/poet"
+	"github.com/buildpacks/libcnb/log"
 )
 
 func testLogger(t *testing.T, context spec.G, it spec.S) {
@@ -32,7 +32,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		b *bytes.Buffer
-		l poet.Logger
+		l log.Logger
 	)
 
 	it.Before(func() {
@@ -41,7 +41,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 
 	context("without BP_DEBUG", func() {
 		it.Before(func() {
-			l = poet.NewLogger(b)
+			l = log.New(b)
 		})
 
 		it("does not configure debug", func() {
@@ -52,7 +52,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 	context("with BP_DEBUG", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_DEBUG", "")).To(Succeed())
-			l = poet.NewLogger(b)
+			l = log.New(b)
 		})
 
 		it.After(func() {
@@ -67,7 +67,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 	context("with BP_LOG_LEVEL set to DEBUG", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_LOG_LEVEL", "DEBUG")).To(Succeed())
-			l = poet.NewLogger(b)
+			l = log.New(b)
 		})
 
 		it.After(func() {
@@ -81,7 +81,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 
 	context("with debug disabled", func() {
 		it.Before(func() {
-			l = poet.NewLoggerWithOptions(b)
+			l = log.NewWithOptions(b)
 		})
 
 		it("does not write debug log", func() {
@@ -123,7 +123,7 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 
 	context("with debug enabled", func() {
 		it.Before(func() {
-			l = poet.NewLoggerWithOptions(b, poet.WithDebug(b))
+			l = log.NewWithOptions(b, log.WithDebug(b))
 		})
 
 		it("writes debug log", func() {


### PR DESCRIPTION
- Renames the poet module to log
- Renames NewLogger to just New, so that you have less redundancy. i.e. log.NewLogger becomes log.New
- Renames NewLoggerWithOptions to just NewWithOptions, so that you have less redundancy. i.e. log.NewLoggerWithOptions becomes log.NewWithOptions
- Renames LogLevel to just Level, so that you have less redundancy. i.e. log.LogLevel becomes log.Level

Resolves #81

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>