### PR TITLE
Updates libcnb to support buildpacks API 0.7

### DIFF
--- a/build.go
+++ b/build.go
@@ -166,8 +166,8 @@ func Build(builder Builder, options ...Option) {
 	logger.Debugf("Buildpack: %+v", ctx.Buildpack)
 
 	API := strings.TrimSpace(ctx.Buildpack.API)
-	if API != "0.5" && API != "0.6" {
-		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack APIs 0.5 and 0.6"))
+	if API != "0.5" && API != "0.6" && API != "0.7" {
+		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack APIs 0.5, 0.6, and 0.7"))
 		return
 	}
 

--- a/build_test.go
+++ b/build_test.go
@@ -181,7 +181,7 @@ test-key = "test-value"
 		Expect(os.RemoveAll(platformPath)).To(Succeed())
 	})
 
-	context("buildpack API is not 0.5 or 0.6", func() {
+	context("buildpack API is not 0.5, 0.6, or 0.7", func() {
 		it.Before(func() {
 			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 				[]byte(`
@@ -203,7 +203,7 @@ version = "1.1.1"
 			)
 
 			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(
-				"this version of libcnb is only compatible with buildpack APIs 0.5 and 0.6",
+				"this version of libcnb is only compatible with buildpack APIs 0.5, 0.6, and 0.7",
 			))
 		})
 	})

--- a/detect.go
+++ b/detect.go
@@ -116,8 +116,8 @@ func Detect(detector Detector, options ...Option) {
 	logger.Debugf("Buildpack: %+v", ctx.Buildpack)
 
 	API := strings.TrimSpace(ctx.Buildpack.API)
-	if API != "0.5" && API != "0.6" {
-		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack API 0.5 and 0.6"))
+	if API != "0.5" && API != "0.6" && API != "0.7" {
+		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack APIs 0.5, 0.6, and 0.7"))
 		return
 	}
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -135,7 +135,7 @@ test-key = "test-value"
 		Expect(os.RemoveAll(platformPath)).To(Succeed())
 	})
 
-	context("buildpack API is not 0.5 or 0.6", func() {
+	context("buildpack API is not 0.5, 0.6, or 0.7", func() {
 		it.Before(func() {
 			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 				[]byte(`
@@ -157,7 +157,7 @@ version = "1.1.1"
 			)
 
 			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(
-				"this version of libcnb is only compatible with buildpack API 0.5 and 0.6",
+				"this version of libcnb is only compatible with buildpack APIs 0.5, 0.6, and 0.7",
 			))
 		})
 	})


### PR DESCRIPTION
Buildpacks API 0.7 brings one new feature, the functionality for SBoM output through [RFC #95](https://github.com/buildpacks/rfcs/blob/main/text/0095-sbom.md).

Without this change, you can write the SBoM information as described in RFC #95, but the lifecycle will ignore it. To make the lifecycle capture your SBoM information you need to:
1. Use a version of libcnb with this PR.
2. Update the `api = "0.8"` line in your buildpack.toml.
3. Write the SBoM files from your buildpack according to the locations in RFC #95. Libcnb does not provide any help with this activity presently, it is up to the buildpack author.
4. Use a lifecycle version with support, 0.13.0+
5. Use a pack version with platform API 0.8+

The lifecycle should then copy your SBoM files and include them into the image.

This PR is only required because the current implementation restricts usage of libcnb to specific buildpack API versions and we needed to add 0.7 to this list.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>