### PR TITLE
Fixes bug with Warning message regarding SBOM format

### DIFF
--- a/build.go
+++ b/build.go
@@ -344,7 +344,7 @@ func Build(builder Builder, options ...Option) {
 		}
 
 		// even if there is data, do not write a BOM if we have buildpack API 0.7, that will cause a lifecycle error
-		if API == "0.7" {
+		if API == "0.7" && len(launch.BOM) > 0 {
 			logger.Info("Warning: this buildpack is including both old and new format SBOM information, which is an invalid state. To prevent the lifecycle from failing, libcnb is discarding the old SBOM information.")
 			launch.BOM = nil
 		}
@@ -365,7 +365,7 @@ func Build(builder Builder, options ...Option) {
 		logger.Debugf("Writing build metadata: %s <= %+v", file, build)
 
 		// even if there is data, do not write a BOM if we have buildpack API 0.7, that will cause a lifecycle error
-		if API == "0.7" {
+		if API == "0.7" && len(build.BOM) > 0 {
 			logger.Info("Warning: this buildpack is including both old and new format SBOM information, which is an invalid state. To prevent the lifecycle from failing, libcnb is discarding the old SBOM information.")
 			build.BOM = nil
 		}


### PR DESCRIPTION
In the current implementation, it is possible for the `Warning: this buildpack is including both old and new format SBOM...` message to be triggered incorrectly. The warning is displayed if the launch or build object are not empty & if the API is `0.7`. This isn't right though. If you have no SBOM entries, but you have process types or labels, then it would be not empty & you'd see this message incorrectly.

This PR adjust the criteria such that you'll see this warning message if launch or build are not empty, if API is `0.7` and if BOM entries is not empty.

This includes tests that validate that the BOM list is squashed to nil when the warning message occurs. We cannot test that the warning did not occur though. If API is `0.7` and we have a non-empty launch/build, the only side-effect we could observe to test is if the log message were written, but that goes to STDOUT so there isn't a good way to validate it.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>