### PR TITLE
Removes the Application struct

### DIFF
--- a/application.go
+++ b/application.go
@@ -16,12 +16,6 @@
 
 package libcnb
 
-// Application is the user contributed application to build.
-type Application struct {
-	// Path is the path to the application.
-	Path string
-}
-
 // Label represents an image label.
 type Label struct {
 	// Key is the key of the label.

--- a/build.go
+++ b/build.go
@@ -32,9 +32,9 @@ import (
 
 // BuildContext contains the inputs to build.
 type BuildContext struct {
-	// WorkingDir is the location of the application source code as provided by
+	// ApplicationPath is the location of the application source code as provided by
 	// the lifecycle.
-	WorkingDir string
+	ApplicationPath string
 
 	// Buildpack is metadata about the buildpack, from buildpack.toml.
 	Buildpack Buildpack
@@ -125,13 +125,13 @@ func Build(build BuildFunc, options ...Option) {
 	ctx := BuildContext{}
 	logger := log.New(os.Stdout)
 
-	ctx.WorkingDir, err = os.Getwd()
+	ctx.ApplicationPath, err = os.Getwd()
 	if err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to get working directory\n%w", err))
 		return
 	}
 	if logger.IsDebugEnabled() {
-		logger.Debug(ApplicationPathFormatter(ctx.WorkingDir))
+		logger.Debug(ApplicationPathFormatter(ctx.ApplicationPath))
 	}
 
 	if s, ok := os.LookupEnv("CNB_BUILDPACK_DIR"); ok {

--- a/build.go
+++ b/build.go
@@ -32,8 +32,9 @@ import (
 
 // BuildContext contains the inputs to build.
 type BuildContext struct {
-	// Application is application to build.
-	Application Application
+	// WorkingDir is the location of the application source code as provided by
+	// the lifecycle.
+	WorkingDir string
 
 	// Buildpack is metadata about the buildpack, from buildpack.toml.
 	Buildpack Buildpack
@@ -124,13 +125,13 @@ func Build(build BuildFunc, options ...Option) {
 	ctx := BuildContext{}
 	logger := log.New(os.Stdout)
 
-	ctx.Application.Path, err = os.Getwd()
+	ctx.WorkingDir, err = os.Getwd()
 	if err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to get working directory\n%w", err))
 		return
 	}
 	if logger.IsDebugEnabled() {
-		logger.Debug(ApplicationPathFormatter(ctx.Application.Path))
+		logger.Debug(ApplicationPathFormatter(ctx.WorkingDir))
 	}
 
 	if s, ok := os.LookupEnv("CNB_BUILDPACK_DIR"); ok {

--- a/build_test.go
+++ b/build_test.go
@@ -237,7 +237,7 @@ version = "1.1.1"
 			libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 		)
 
-		Expect(ctx.Application).To(Equal(libcnb.Application{Path: applicationPath}))
+		Expect(ctx.WorkingDir).To(Equal(applicationPath))
 		Expect(ctx.Buildpack).To(Equal(libcnb.Buildpack{
 			API: "0.6",
 			Info: libcnb.BuildpackInfo{

--- a/build_test.go
+++ b/build_test.go
@@ -237,7 +237,7 @@ version = "1.1.1"
 			libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 		)
 
-		Expect(ctx.WorkingDir).To(Equal(applicationPath))
+		Expect(ctx.ApplicationPath).To(Equal(applicationPath))
 		Expect(ctx.Buildpack).To(Equal(libcnb.Buildpack{
 			API: "0.6",
 			Info: libcnb.BuildpackInfo{

--- a/detect.go
+++ b/detect.go
@@ -32,8 +32,9 @@ import (
 // DetectContext contains the inputs to detection.
 type DetectContext struct {
 
-	// Application is the application to build.
-	Application Application
+	// WorkingDir is the location of the application source code as provided by
+	// the lifecycle.
+	WorkingDir string
 
 	// Buildpack is metadata about the buildpack, from buildpack.toml.
 	Buildpack Buildpack
@@ -86,13 +87,13 @@ func Detect(detect DetectFunc, options ...Option) {
 	ctx := DetectContext{}
 	logger := log.New(os.Stdout)
 
-	ctx.Application.Path, err = os.Getwd()
+	ctx.WorkingDir, err = os.Getwd()
 	if err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to get working directory\n%w", err))
 		return
 	}
 	if logger.IsDebugEnabled() {
-		logger.Debug(ApplicationPathFormatter(ctx.Application.Path))
+		logger.Debug(ApplicationPathFormatter(ctx.WorkingDir))
 	}
 
 	if s, ok := os.LookupEnv("CNB_BUILDPACK_DIR"); ok {

--- a/detect.go
+++ b/detect.go
@@ -32,9 +32,9 @@ import (
 // DetectContext contains the inputs to detection.
 type DetectContext struct {
 
-	// WorkingDir is the location of the application source code as provided by
+	// ApplicationPath is the location of the application source code as provided by
 	// the lifecycle.
-	WorkingDir string
+	ApplicationPath string
 
 	// Buildpack is metadata about the buildpack, from buildpack.toml.
 	Buildpack Buildpack
@@ -87,13 +87,13 @@ func Detect(detect DetectFunc, options ...Option) {
 	ctx := DetectContext{}
 	logger := log.New(os.Stdout)
 
-	ctx.WorkingDir, err = os.Getwd()
+	ctx.ApplicationPath, err = os.Getwd()
 	if err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to get working directory\n%w", err))
 		return
 	}
 	if logger.IsDebugEnabled() {
-		logger.Debug(ApplicationPathFormatter(ctx.WorkingDir))
+		logger.Debug(ApplicationPathFormatter(ctx.ApplicationPath))
 	}
 
 	if s, ok := os.LookupEnv("CNB_BUILDPACK_DIR"); ok {

--- a/detect_test.go
+++ b/detect_test.go
@@ -196,7 +196,7 @@ version = "1.1.1"
 			libcnb.WithExitHandler(exitHandler),
 		)
 
-		Expect(ctx.WorkingDir).To(Equal(applicationPath))
+		Expect(ctx.ApplicationPath).To(Equal(applicationPath))
 		Expect(ctx.Buildpack).To(Equal(libcnb.Buildpack{
 			API: "0.6",
 			Info: libcnb.BuildpackInfo{

--- a/detect_test.go
+++ b/detect_test.go
@@ -196,7 +196,7 @@ version = "1.1.1"
 			libcnb.WithExitHandler(exitHandler),
 		)
 
-		Expect(ctx.Application).To(Equal(libcnb.Application{Path: applicationPath}))
+		Expect(ctx.WorkingDir).To(Equal(applicationPath))
 		Expect(ctx.Buildpack).To(Equal(libcnb.Buildpack{
 			API: "0.6",
 			Info: libcnb.BuildpackInfo{


### PR DESCRIPTION
- Currently the Application struct is just a wrapper for the WorkingDir
that is specified by the lifecycle. This adds an unneed layer of
abstracation and strays away from the terminology that is used in the
buildpacks spec. Instead the WorkingDir is just a string fields on both
the Build and Detect contexts that conveys the same information.

Signed-off-by: Forest Eckhardt <feckhardt@pivotal.io>