### PR TITLE
Validation should only occur under API 0.7

### DIFF
--- a/build.go
+++ b/build.go
@@ -306,9 +306,11 @@ func Build(builder Builder, options ...Option) {
 		}
 	}
 
-	if err := validateSBOMFormats(ctx.Layers.Path, ctx.Buildpack.Info.SBOMFormats); err != nil {
-		config.exitHandler.Error(fmt.Errorf("unable to validate SBOM\n%w", err))
-		return
+	if API != "0.1" && API != "0.2" && API != "0.3" && API != "0.4" && API != "0.5" && API != "0.6" {
+		if err := validateSBOMFormats(ctx.Layers.Path, ctx.Buildpack.Info.SBOMFormats); err != nil {
+			config.exitHandler.Error(fmt.Errorf("unable to validate SBOM\n%w", err))
+			return
+		}
 	}
 
 	// Deprecated: as of Buildpack API 0.7, to be removed in a future version

--- a/build_test.go
+++ b/build_test.go
@@ -769,6 +769,30 @@ sbom-formats = []
 			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("unable to validate SBOM\nunable to find actual SBOM Type application/spdx+json in list of supported SBOM types []"))
 		})
 
+		it("skips if API is not 0.7", func() {
+			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
+				[]byte(`
+api = "0.6"
+
+[buildpack]
+id = "test-id"
+name = "test-name"
+version = "1.1.1"
+sbom-formats = []
+`),
+				0600),
+			).To(Succeed())
+
+			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
+
+			libcnb.Build(builder,
+				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+			)
+
+			Expect(exitHandler.Calls).To(BeEmpty())
+		})
+
 		it("has no matching formats", func() {
 			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
 


### PR DESCRIPTION
- Adds API checks before validating SBOM format, should only happen with API 0.7+
- Adds a test to confirm validation does not run if the API is less than 0.7.

Resolves #107

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>