### PR TITLE
Only validate for API versions 0.5 and 0.6

### DIFF
--- a/build.go
+++ b/build.go
@@ -306,7 +306,7 @@ func Build(builder Builder, options ...Option) {
 		}
 	}
 
-	if API != "0.1" && API != "0.2" && API != "0.3" && API != "0.4" && API != "0.5" && API != "0.6" {
+	if API != "0.5" && API != "0.6" {
 		if err := validateSBOMFormats(ctx.Layers.Path, ctx.Buildpack.Info.SBOMFormats); err != nil {
 			config.exitHandler.Error(fmt.Errorf("unable to validate SBOM\n%w", err))
 			return


### PR DESCRIPTION
libcnb is only supported for versions 0.5+ and we check for it a few lines above. Removing some unnecessary checks

Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>