### PR TITLE
Catch up to main with v2 SBOM Changes

### DIFF
--- a/build.go
+++ b/build.go
@@ -274,7 +274,7 @@ func Build(build BuildFunc, options ...Option) {
 		}
 	}
 
-	if API != "0.1" && API != "0.2" && API != "0.3" && API != "0.4" && API != "0.5" && API != "0.6" {
+	if API != "0.5" && API != "0.6" {
 		if err := validateSBOMFormats(ctx.Layers.Path, ctx.Buildpack.Info.SBOMFormats); err != nil {
 			config.exitHandler.Error(fmt.Errorf("unable to validate SBOM\n%w", err))
 			return

--- a/build.go
+++ b/build.go
@@ -274,7 +274,7 @@ func Build(build BuildFunc, options ...Option) {
 		}
 	}
 
-	if err := ValidateSBOMFormats(ctx.Layers.Path, ctx.Buildpack.Info.SBOMFormats); err != nil {
+	if err := validateSBOMFormats(ctx.Layers.Path, ctx.Buildpack.Info.SBOMFormats); err != nil {
 		config.exitHandler.Error(fmt.Errorf("unable to validate SBOM\n%w", err))
 		return
 	}
@@ -340,7 +340,7 @@ func contains(candidates []string, s string) bool {
 	return false
 }
 
-func ValidateSBOMFormats(layersPath string, acceptedSBOMFormats []string) error {
+func validateSBOMFormats(layersPath string, acceptedSBOMFormats []string) error {
 	sbomFiles, err := filepath.Glob(filepath.Join(layersPath, "*.sbom.*"))
 	if err != nil {
 		return fmt.Errorf("unable find SBOM files\n%w", err)

--- a/build.go
+++ b/build.go
@@ -274,9 +274,11 @@ func Build(build BuildFunc, options ...Option) {
 		}
 	}
 
-	if err := validateSBOMFormats(ctx.Layers.Path, ctx.Buildpack.Info.SBOMFormats); err != nil {
-		config.exitHandler.Error(fmt.Errorf("unable to validate SBOM\n%w", err))
-		return
+	if API != "0.1" && API != "0.2" && API != "0.3" && API != "0.4" && API != "0.5" && API != "0.6" {
+		if err := validateSBOMFormats(ctx.Layers.Path, ctx.Buildpack.Info.SBOMFormats); err != nil {
+			config.exitHandler.Error(fmt.Errorf("unable to validate SBOM\n%w", err))
+			return
+		}
 	}
 
 	launch := LaunchTOML{

--- a/build.go
+++ b/build.go
@@ -274,6 +274,11 @@ func Build(build BuildFunc, options ...Option) {
 		}
 	}
 
+	if err := ValidateSBOMFormats(ctx.Layers.Path, ctx.Buildpack.Info.SBOMFormats); err != nil {
+		config.exitHandler.Error(fmt.Errorf("unable to validate SBOM\n%w", err))
+		return
+	}
+
 	launch := LaunchTOML{
 		Labels:    result.Labels,
 		Processes: result.Processes,
@@ -305,6 +310,7 @@ func Build(build BuildFunc, options ...Option) {
 	if !buildTOML.isEmpty() {
 		file = filepath.Join(ctx.Layers.Path, "build.toml")
 		logger.Debugf("Writing build metadata: %s <= %+v", file, build)
+
 		if err = config.tomlWriter.Write(file, buildTOML); err != nil {
 			config.exitHandler.Error(fmt.Errorf("unable to write build metadata %s\n%w", file, err))
 			return
@@ -332,4 +338,28 @@ func contains(candidates []string, s string) bool {
 	}
 
 	return false
+}
+
+func ValidateSBOMFormats(layersPath string, acceptedSBOMFormats []string) error {
+	sbomFiles, err := filepath.Glob(filepath.Join(layersPath, "*.sbom.*"))
+	if err != nil {
+		return fmt.Errorf("unable find SBOM files\n%w", err)
+	}
+
+	for _, sbomFile := range sbomFiles {
+		parts := strings.Split(filepath.Base(sbomFile), ".")
+		if len(parts) <= 2 {
+			return fmt.Errorf("invalid format %s", filepath.Base(sbomFile))
+		}
+		sbomFormat, err := SBOMFormatFromString(strings.Join(parts[len(parts)-2:], "."))
+		if err != nil {
+			return fmt.Errorf("unable to parse SBOM %s\n%w", sbomFormat, err)
+		}
+
+		if !contains(acceptedSBOMFormats, sbomFormat.MediaType()) {
+			return fmt.Errorf("unable to find actual SBOM Type %s in list of supported SBOM types %s", sbomFormat.MediaType(), acceptedSBOMFormats)
+		}
+	}
+
+	return nil
 }

--- a/build.go
+++ b/build.go
@@ -151,8 +151,8 @@ func Build(build BuildFunc, options ...Option) {
 	logger.Debugf("Buildpack: %+v", ctx.Buildpack)
 
 	API := strings.TrimSpace(ctx.Buildpack.API)
-	if API != "0.5" && API != "0.6" {
-		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack APIs 0.5 and 0.6"))
+	if API != "0.5" && API != "0.6" && API != "0.7" {
+		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack APIs 0.5, 0.6, and 0.7"))
 		return
 	}
 

--- a/build_test.go
+++ b/build_test.go
@@ -588,11 +588,13 @@ sbom-formats = ["application/vnd.cyclonedx+json"]
 				0600),
 			).To(Succeed())
 
-			builder.On("Build", mock.Anything).Return(libcnb.BuildResult{}, nil)
+			buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
+				return libcnb.BuildResult{}, nil
+			}
 		})
 
 		it("has no SBOM files", func() {
-			libcnb.Build(builder,
+			libcnb.Build(buildFunc,
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 			)
@@ -616,7 +618,7 @@ sbom-formats = []
 
 			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
 
-			libcnb.Build(builder,
+			libcnb.Build(buildFunc,
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 			)
@@ -627,7 +629,7 @@ sbom-formats = []
 		it("has no matching formats", func() {
 			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
 
-			libcnb.Build(builder,
+			libcnb.Build(buildFunc,
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 			)
@@ -638,7 +640,7 @@ sbom-formats = []
 		it("has a matching format", func() {
 			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.cdx.json"), []byte{}, 0600)).To(Succeed())
 			Expect(ioutil.WriteFile(filepath.Join(layersPath, "layer.sbom.cdx.json"), []byte{}, 0600)).To(Succeed())
-			libcnb.Build(builder,
+			libcnb.Build(buildFunc,
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 			)
@@ -649,7 +651,7 @@ sbom-formats = []
 		it("has a junk format", func() {
 			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.random.json"), []byte{}, 0600)).To(Succeed())
 			Expect(ioutil.WriteFile(filepath.Join(layersPath, "layer.sbom.cdx.json"), []byte{}, 0600)).To(Succeed())
-			libcnb.Build(builder,
+			libcnb.Build(buildFunc,
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 			)

--- a/build_test.go
+++ b/build_test.go
@@ -179,7 +179,7 @@ test-key = "test-value"
 		Expect(os.RemoveAll(platformPath)).To(Succeed())
 	})
 
-	context("buildpack API is not 0.5 or 0.6", func() {
+	context("buildpack API is not 0.5, 0.6, or 0.7", func() {
 		it.Before(func() {
 			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 				[]byte(`
@@ -201,7 +201,7 @@ version = "1.1.1"
 			)
 
 			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(
-				"this version of libcnb is only compatible with buildpack APIs 0.5 and 0.6",
+				"this version of libcnb is only compatible with buildpack APIs 0.5, 0.6, and 0.7",
 			))
 		})
 	})

--- a/build_test.go
+++ b/build_test.go
@@ -626,6 +626,30 @@ sbom-formats = []
 			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("unable to validate SBOM\nunable to find actual SBOM Type application/spdx+json in list of supported SBOM types []"))
 		})
 
+		it("skips if API is not 0.7", func() {
+			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
+				[]byte(`
+api = "0.6"
+
+[buildpack]
+id = "test-id"
+name = "test-name"
+version = "1.1.1"
+sbom-formats = []
+`),
+				0600),
+			).To(Succeed())
+
+			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
+
+			libcnb.Build(builder,
+				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+			)
+
+			Expect(exitHandler.Calls).To(BeEmpty())
+		})
+
 		it("has no matching formats", func() {
 			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
 

--- a/build_test.go
+++ b/build_test.go
@@ -572,4 +572,30 @@ version = "1.1.1"
 			},
 		}))
 	})
+
+	context("Validates SBOM entries", func() {
+		it("has no SBOM files", func() {
+			Expect(libcnb.ValidateSBOMFormats(layersPath, []string{})).To(BeNil())
+		})
+
+		it("has no accepted formats", func() {
+			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
+			Expect(libcnb.ValidateSBOMFormats(layersPath, []string{})).To(MatchError("unable to find actual SBOM Type application/spdx+json in list of supported SBOM types []"))
+		})
+
+		it("has no matching formats", func() {
+			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
+			Expect(libcnb.ValidateSBOMFormats(layersPath, []string{"application/vnd.cyclonedx+json"})).To(MatchError("unable to find actual SBOM Type application/spdx+json in list of supported SBOM types [application/vnd.cyclonedx+json]"))
+		})
+
+		it("has a matching format", func() {
+			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
+			Expect(libcnb.ValidateSBOMFormats(layersPath, []string{"application/vnd.cyclonedx+json", "application/spdx+json"})).To(BeNil())
+		})
+
+		it("has an invalid format", func() {
+			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.junk.json"), []byte{}, 0600)).To(Succeed())
+			Expect(libcnb.ValidateSBOMFormats(layersPath, []string{})).To(MatchError("unable to parse SBOM unknown\nunable to translate from junk.json to SBOMFormat"))
+		})
+	})
 }

--- a/build_test.go
+++ b/build_test.go
@@ -642,7 +642,7 @@ sbom-formats = []
 
 			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
 
-			libcnb.Build(builder,
+			libcnb.Build(buildFunc,
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 			)

--- a/build_test.go
+++ b/build_test.go
@@ -574,28 +574,87 @@ version = "1.1.1"
 	})
 
 	context("Validates SBOM entries", func() {
+		it.Before(func() {
+			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
+				[]byte(`
+api = "0.7"
+
+[buildpack]
+id = "test-id"
+name = "test-name"
+version = "1.1.1"
+sbom-formats = ["application/vnd.cyclonedx+json"]
+`),
+				0600),
+			).To(Succeed())
+
+			builder.On("Build", mock.Anything).Return(libcnb.BuildResult{}, nil)
+		})
+
 		it("has no SBOM files", func() {
-			Expect(libcnb.ValidateSBOMFormats(layersPath, []string{})).To(BeNil())
+			libcnb.Build(builder,
+				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+			)
+
+			Expect(exitHandler.Calls).To(BeEmpty())
 		})
 
 		it("has no accepted formats", func() {
+			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
+				[]byte(`
+api = "0.7"
+
+[buildpack]
+id = "test-id"
+name = "test-name"
+version = "1.1.1"
+sbom-formats = []
+`),
+				0600),
+			).To(Succeed())
+
 			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
-			Expect(libcnb.ValidateSBOMFormats(layersPath, []string{})).To(MatchError("unable to find actual SBOM Type application/spdx+json in list of supported SBOM types []"))
+
+			libcnb.Build(builder,
+				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+			)
+
+			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("unable to validate SBOM\nunable to find actual SBOM Type application/spdx+json in list of supported SBOM types []"))
 		})
 
 		it("has no matching formats", func() {
 			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
-			Expect(libcnb.ValidateSBOMFormats(layersPath, []string{"application/vnd.cyclonedx+json"})).To(MatchError("unable to find actual SBOM Type application/spdx+json in list of supported SBOM types [application/vnd.cyclonedx+json]"))
+
+			libcnb.Build(builder,
+				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+			)
+
+			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("unable to validate SBOM\nunable to find actual SBOM Type application/spdx+json in list of supported SBOM types [application/vnd.cyclonedx+json]"))
 		})
 
 		it("has a matching format", func() {
-			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
-			Expect(libcnb.ValidateSBOMFormats(layersPath, []string{"application/vnd.cyclonedx+json", "application/spdx+json"})).To(BeNil())
+			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.cdx.json"), []byte{}, 0600)).To(Succeed())
+			Expect(ioutil.WriteFile(filepath.Join(layersPath, "layer.sbom.cdx.json"), []byte{}, 0600)).To(Succeed())
+			libcnb.Build(builder,
+				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+			)
+
+			Expect(exitHandler.Calls).To(BeEmpty())
 		})
 
-		it("has an invalid format", func() {
-			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.junk.json"), []byte{}, 0600)).To(Succeed())
-			Expect(libcnb.ValidateSBOMFormats(layersPath, []string{})).To(MatchError("unable to parse SBOM unknown\nunable to translate from junk.json to SBOMFormat"))
+		it("has a junk format", func() {
+			Expect(ioutil.WriteFile(filepath.Join(layersPath, "launch.sbom.random.json"), []byte{}, 0600)).To(Succeed())
+			Expect(ioutil.WriteFile(filepath.Join(layersPath, "layer.sbom.cdx.json"), []byte{}, 0600)).To(Succeed())
+			libcnb.Build(builder,
+				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+			)
+
+			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("unable to validate SBOM\nunable to parse SBOM unknown\nunable to translate from random.json to SBOMFormat"))
 		})
 	})
 }

--- a/buildpack.go
+++ b/buildpack.go
@@ -41,6 +41,9 @@ type BuildpackInfo struct {
 
 	// Licenses a list of buildpack licenses.
 	Licenses []License `toml:"licenses"`
+
+	// SBOM is the list of supported SBOM media types
+	SBOMFormats []string `toml:"sbom-formats"`
 }
 
 // License contains information about a Software License

--- a/detect.go
+++ b/detect.go
@@ -111,8 +111,8 @@ func Detect(detect DetectFunc, options ...Option) {
 	logger.Debugf("Buildpack: %+v", ctx.Buildpack)
 
 	API := strings.TrimSpace(ctx.Buildpack.API)
-	if API != "0.5" && API != "0.6" {
-		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack API 0.5 and 0.6"))
+	if API != "0.5" && API != "0.6" && API != "0.7" {
+		config.exitHandler.Error(errors.New("this version of libcnb is only compatible with buildpack APIs 0.5, 0.6, and 0.7"))
 		return
 	}
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -137,7 +137,7 @@ test-key = "test-value"
 		Expect(os.RemoveAll(platformPath)).To(Succeed())
 	})
 
-	context("buildpack API is not 0.5 or 0.6", func() {
+	context("buildpack API is not 0.5, 0.6, or 0.7", func() {
 		it.Before(func() {
 			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 				[]byte(`
@@ -159,7 +159,7 @@ version = "1.1.1"
 			)
 
 			Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(
-				"this version of libcnb is only compatible with buildpack API 0.5 and 0.6",
+				"this version of libcnb is only compatible with buildpack APIs 0.5, 0.6, and 0.7",
 			))
 		})
 	})

--- a/layer.go
+++ b/layer.go
@@ -26,6 +26,16 @@ import (
 	"github.com/buildpacks/libcnb/internal"
 )
 
+const (
+	BOMFormatCycloneDXExtension = "cdx.json"
+	BOMFormatSPDXExtension      = "spdx.json"
+	BOMFormatSyftExtension      = "syft.json"
+	BOMMediaTypeCycloneDX       = "application/vnd.cyclonedx+json"
+	BOMMediaTypeSPDX            = "application/spdx+json"
+	BOMMediaTypeSyft            = "application/vnd.syft+json"
+	BOMUnknown                  = "unknown"
+)
+
 // Exec represents the exec.d layer location
 type Exec struct {
 	// Path is the path to the exec.d directory.
@@ -74,10 +84,36 @@ const (
 	CycloneDXJSON SBOMFormat = iota
 	SPDXJSON
 	SyftJSON
+	UnknownFormat
 )
 
 func (b SBOMFormat) String() string {
-	return []string{"cdx.json", "spdx.json", "syft.json"}[b]
+	return []string{
+		BOMFormatCycloneDXExtension,
+		BOMFormatSPDXExtension,
+		BOMFormatSyftExtension,
+		BOMUnknown}[b]
+}
+
+func (b SBOMFormat) MediaType() string {
+	return []string{
+		BOMMediaTypeCycloneDX,
+		BOMMediaTypeSPDX,
+		BOMMediaTypeSyft,
+		BOMUnknown}[b]
+}
+
+func SBOMFormatFromString(from string) (SBOMFormat, error) {
+	switch from {
+	case CycloneDXJSON.String():
+		return CycloneDXJSON, nil
+	case SPDXJSON.String():
+		return SPDXJSON, nil
+	case SyftJSON.String():
+		return SyftJSON, nil
+	}
+
+	return UnknownFormat, fmt.Errorf("unable to translate from %s to SBOMFormat", from)
 }
 
 // Contribute represents a layer managed by the buildpack.

--- a/layer_test.go
+++ b/layer_test.go
@@ -110,7 +110,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			Expect(l.Profile).To(Equal(libcnb.Profile{}))
 		})
 
-		it("generates BOM paths", func() {
+		it("generates SBOM paths", func() {
 			l, err := layers.Layer("test-name")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -120,6 +120,24 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			Expect(layers.BuildSBOMPath(libcnb.SyftJSON)).To(Equal(filepath.Join(path, "build.sbom.syft.json")))
 			Expect(layers.LaunchSBOMPath(libcnb.SyftJSON)).To(Equal(filepath.Join(path, "launch.sbom.syft.json")))
 			Expect(l.SBOMPath(libcnb.SyftJSON)).To(Equal(filepath.Join(path, "test-name.sbom.syft.json")))
+		})
+
+		it("maps from string to SBOM Format", func() {
+			fmt, err := libcnb.SBOMFormatFromString("cdx.json")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fmt).To(Equal(libcnb.CycloneDXJSON))
+
+			fmt, err = libcnb.SBOMFormatFromString("spdx.json")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fmt).To(Equal(libcnb.SPDXJSON))
+
+			fmt, err = libcnb.SBOMFormatFromString("syft.json")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fmt).To(Equal(libcnb.SyftJSON))
+
+			fmt, err = libcnb.SBOMFormatFromString("foobar.json")
+			Expect(err).To(MatchError("unable to translate from foobar.json to SBOMFormat"))
+			Expect(fmt).To(Equal(libcnb.UnknownFormat))
 		})
 
 		it("reads existing 0.5 metadata", func() {


### PR DESCRIPTION
This PR catches up the v2 branch to the main branch in terms of SBOM support.

Here are the highlights:

- Adds support for allowing buildpack API 0.7
- Adds validation of the SBOM format based on what is in buildpack.toml

I intentionally left multiple commits on this PR so you could see which ones were pulled over from main. I ran them in order so we ended up with the same thing on v2 (except where things have diverged around build). If you want to squash these down when merging, feel free.