### PR TITLE
Removes usage of ioutil

### DIFF
--- a/detect_test.go
+++ b/detect_test.go
@@ -18,7 +18,6 @@ package libcnb_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,16 +50,16 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		applicationPath, err = ioutil.TempDir("", "detect-application-path")
+		applicationPath, err = os.MkdirTemp("", "detect-application-path")
 		Expect(err).NotTo(HaveOccurred())
 		applicationPath, err = filepath.EvalSymlinks(applicationPath)
 		Expect(err).NotTo(HaveOccurred())
 
-		buildpackPath, err = ioutil.TempDir("", "detect-buildpack-path")
+		buildpackPath, err = os.MkdirTemp("", "detect-buildpack-path")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Setenv("CNB_BUILDPACK_DIR", buildpackPath)).To(Succeed())
 
-		Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
+		Expect(os.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 			[]byte(`
 api = "0.6"
 
@@ -90,7 +89,7 @@ test-key = "test-value"
 			0600),
 		).To(Succeed())
 
-		f, err := ioutil.TempFile("", "detect-buildplan-path")
+		f, err := os.CreateTemp("", "detect-buildplan-path")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).NotTo(HaveOccurred())
 		buildPlanPath = f.Name()
@@ -106,15 +105,15 @@ test-key = "test-value"
 		exitHandler.On("Fail")
 		exitHandler.On("Pass")
 
-		platformPath, err = ioutil.TempDir("", "detect-platform-path")
+		platformPath, err = os.MkdirTemp("", "detect-platform-path")
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(os.MkdirAll(filepath.Join(platformPath, "bindings", "alpha"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(platformPath, "bindings", "alpha", "test-secret-key"),
+		Expect(os.WriteFile(filepath.Join(platformPath, "bindings", "alpha", "test-secret-key"),
 			[]byte("test-secret-value"), 0600)).To(Succeed())
 
 		Expect(os.MkdirAll(filepath.Join(platformPath, "env"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(platformPath, "env", "TEST_ENV"), []byte("test-value"), 0600)).
+		Expect(os.WriteFile(filepath.Join(platformPath, "env", "TEST_ENV"), []byte("test-value"), 0600)).
 			To(Succeed())
 
 		tomlWriter = &mocks.TOMLWriter{}
@@ -140,7 +139,7 @@ test-key = "test-value"
 
 	context("buildpack API is not 0.5, 0.6, or 0.7", func() {
 		it.Before(func() {
-			Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
+			Expect(os.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 				[]byte(`
 api = "0.4"
 

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -17,7 +17,6 @@
 package libcnb_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			app, err = ioutil.TempDir("", "application-path-formatter")
+			app, err = os.MkdirTemp("", "application-path-formatter")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -68,7 +67,7 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			bp, err = ioutil.TempDir("", "buildpack-path-formatter")
+			bp, err = os.MkdirTemp("", "buildpack-path-formatter")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -96,7 +95,7 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			plat.Path, err = ioutil.TempDir("", "platform-formatter")
+			plat.Path, err = os.MkdirTemp("", "platform-formatter")
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/internal/config_map.go
+++ b/internal/config_map.go
@@ -18,7 +18,6 @@ package internal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +44,7 @@ func NewConfigMapFromPath(path string) (ConfigMap, error) {
 		} else if stat.IsDir() {
 			continue
 		}
-		contents, err := ioutil.ReadFile(file)
+		contents, err := os.ReadFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read file %s\n%w", file, err)
 		}

--- a/internal/config_map_test.go
+++ b/internal/config_map_test.go
@@ -17,7 +17,6 @@
 package internal_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +36,7 @@ func testConfigMap(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		path, err = ioutil.TempDir("", "config-map")
+		path, err = os.MkdirTemp("", "config-map")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -55,7 +54,7 @@ func testConfigMap(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("loads the ConfigMap from a directory", func() {
-		Expect(ioutil.WriteFile(filepath.Join(path, "test-key"), []byte("test-value"), 0600)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "test-key"), []byte("test-value"), 0600)).To(Succeed())
 
 		cm, err := internal.NewConfigMapFromPath(path)
 		Expect(err).NotTo(HaveOccurred())
@@ -66,7 +65,7 @@ func testConfigMap(t *testing.T, context spec.G, it spec.S) {
 	it("ignores dirs and follows symlinks", func() {
 		// this is necessary to support bindings mounted as k8s config maps & secrets
 		Expect(os.MkdirAll(filepath.Join(path, ".hidden"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(
+		Expect(os.WriteFile(
 			filepath.Join(path, ".hidden", "test-key"),
 			[]byte("test-value"),
 			0600,
@@ -82,7 +81,7 @@ func testConfigMap(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("ignores hidden files", func() {
-		Expect(ioutil.WriteFile(filepath.Join(path, ".hidden-key"), []byte("hidden-value"), 0600)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, ".hidden-key"), []byte("hidden-value"), 0600)).To(Succeed())
 
 		cm, err := internal.NewConfigMapFromPath(path)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/directory_contents_test.go
+++ b/internal/directory_contents_test.go
@@ -17,7 +17,6 @@
 package internal_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +36,7 @@ func testDirectoryContents(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		path, err = ioutil.TempDir("", "directory-contents")
+		path, err = os.MkdirTemp("", "directory-contents")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/internal/environment_writer.go
+++ b/internal/environment_writer.go
@@ -18,7 +18,6 @@ package internal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -39,7 +38,7 @@ func (w EnvironmentWriter) Write(path string, environment map[string]string) err
 	for key, value := range environment {
 		f := filepath.Join(path, key)
 		// #nosec
-		if err := ioutil.WriteFile(f, []byte(value), 0644); err != nil {
+		if err := os.WriteFile(f, []byte(value), 0644); err != nil {
 			return fmt.Errorf("unable to write file %s\n%w", f, err)
 		}
 	}

--- a/internal/environment_writer_test.go
+++ b/internal/environment_writer_test.go
@@ -17,7 +17,6 @@
 package internal_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +37,7 @@ func testEnvironmentWriter(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		path, err = ioutil.TempDir("", "environment-writer")
+		path, err = os.MkdirTemp("", "environment-writer")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.RemoveAll(path)).To(Succeed())
 	})
@@ -54,11 +53,11 @@ func testEnvironmentWriter(t *testing.T, context spec.G, it spec.S) {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		content, err := ioutil.ReadFile(filepath.Join(path, "some-name"))
+		content, err := os.ReadFile(filepath.Join(path, "some-name"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(content)).To(Equal("some-content"))
 
-		content, err = ioutil.ReadFile(filepath.Join(path, "other-name"))
+		content, err = os.ReadFile(filepath.Join(path, "other-name"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(content)).To(Equal("other-content"))
 	})

--- a/internal/toml_writer_test.go
+++ b/internal/toml_writer_test.go
@@ -17,7 +17,6 @@
 package internal_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ func testTOMLWriter(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		parent, err = ioutil.TempDir("", "toml-writer")
+		parent, err = os.MkdirTemp("", "toml-writer")
 		Expect(err).NotTo(HaveOccurred())
 
 		path = filepath.Join(parent, "text.toml")
@@ -56,7 +55,7 @@ func testTOMLWriter(t *testing.T, context spec.G, it spec.S) {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(ioutil.ReadFile(path)).To(internal.MatchTOML(`
+		Expect(os.ReadFile(path)).To(internal.MatchTOML(`
 some-field = "some-value"
 other-field = "other-value"`))
 	})

--- a/layer_test.go
+++ b/layer_test.go
@@ -17,7 +17,6 @@
 package libcnb_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -84,7 +83,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 	context("Layers", func() {
 		it.Before(func() {
 			var err error
-			path, err = ioutil.TempDir("", "layers")
+			path, err = os.MkdirTemp("", "layers")
 			Expect(err).NotTo(HaveOccurred())
 
 			layers = libcnb.Layers{Path: path}
@@ -141,7 +140,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("reads existing 0.5 metadata", func() {
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				filepath.Join(path, "test-name.toml"),
 				[]byte(`
 launch = true
@@ -162,7 +161,7 @@ test-key = "test-value"
 		})
 
 		it("reads existing 0.6 metadata", func() {
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				filepath.Join(path, "test-name.toml"),
 				[]byte(`
 [types]
@@ -184,7 +183,7 @@ test-key = "test-value"
 		})
 
 		it("reads existing 0.6 metadata with launch, build and cache all false", func() {
-			Expect(ioutil.WriteFile(
+			Expect(os.WriteFile(
 				filepath.Join(path, "test-name.toml"),
 				[]byte(`
 [types]

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,6 @@
 package libcnb_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,7 +52,7 @@ func testMain(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		applicationPath, err = ioutil.TempDir("", "main-application-path")
+		applicationPath, err = os.MkdirTemp("", "main-application-path")
 		Expect(err).NotTo(HaveOccurred())
 		applicationPath, err = filepath.EvalSymlinks(applicationPath)
 		Expect(err).NotTo(HaveOccurred())
@@ -62,11 +61,11 @@ func testMain(t *testing.T, context spec.G, it spec.S) {
 			return libcnb.NewBuildResult(), nil
 		}
 
-		buildpackPath, err = ioutil.TempDir("", "main-buildpack-path")
+		buildpackPath, err = os.MkdirTemp("", "main-buildpack-path")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.Setenv("CNB_BUILDPACK_DIR", buildpackPath)).To(Succeed())
 
-		Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
+		Expect(os.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),
 			[]byte(`
 api = "0.6"
 
@@ -92,12 +91,12 @@ test-key = "test-value"
 			0600),
 		).To(Succeed())
 
-		f, err := ioutil.TempFile("", "main-buildpackplan-path")
+		f, err := os.CreateTemp("", "main-buildpackplan-path")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).NotTo(HaveOccurred())
 		buildpackPlanPath = f.Name()
 
-		Expect(ioutil.WriteFile(buildpackPlanPath,
+		Expect(os.WriteFile(buildpackPlanPath,
 			[]byte(`
 [[entries]]
 name = "test-name"
@@ -109,7 +108,7 @@ test-key = "test-value"
 			0600),
 		).To(Succeed())
 
-		f, err = ioutil.TempFile("", "main-buildplan-path")
+		f, err = os.CreateTemp("", "main-buildplan-path")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f.Close()).NotTo(HaveOccurred())
 		buildPlanPath = f.Name()
@@ -126,10 +125,10 @@ test-key = "test-value"
 		exitHandler.On("Pass", mock.Anything)
 		exitHandler.On("Fail", mock.Anything)
 
-		layersPath, err = ioutil.TempDir("", "main-layers-path")
+		layersPath, err = os.MkdirTemp("", "main-layers-path")
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(ioutil.WriteFile(filepath.Join(layersPath, "store.toml"),
+		Expect(os.WriteFile(filepath.Join(layersPath, "store.toml"),
 			[]byte(`
 [metadata]
 test-key = "test-value"
@@ -137,24 +136,24 @@ test-key = "test-value"
 			0600),
 		).To(Succeed())
 
-		platformPath, err = ioutil.TempDir("", "main-platform-path")
+		platformPath, err = os.MkdirTemp("", "main-platform-path")
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(os.MkdirAll(filepath.Join(platformPath, "bindings", "alpha", "metadata"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(
+		Expect(os.WriteFile(
 			filepath.Join(platformPath, "bindings", "alpha", "metadata", "test-metadata-key"),
 			[]byte("test-metadata-value"),
 			0600,
 		)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(platformPath, "bindings", "alpha", "secret"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(
+		Expect(os.WriteFile(
 			filepath.Join(platformPath, "bindings", "alpha", "secret", "test-secret-key"),
 			[]byte("test-secret-value"),
 			0600,
 		)).To(Succeed())
 
 		Expect(os.MkdirAll(filepath.Join(platformPath, "env"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(platformPath, "env", "TEST_ENV"), []byte("test-value"), 0600)).
+		Expect(os.WriteFile(filepath.Join(platformPath, "env", "TEST_ENV"), []byte("test-value"), 0600)).
 			To(Succeed())
 
 		tomlWriter = &mocks.TOMLWriter{}

--- a/platform_test.go
+++ b/platform_test.go
@@ -18,7 +18,6 @@ package libcnb_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +37,7 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		platformPath, err = ioutil.TempDir("", "platform")
+		platformPath, err = os.MkdirTemp("", "platform")
 		path = filepath.Join(platformPath, "bindings")
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -50,18 +49,18 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 	context("Kubernetes Service Bindings", func() {
 		it.Before(func() {
 			Expect(os.MkdirAll(filepath.Join(path, "alpha"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, "alpha", "type"), []byte("test-type"), 0600)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, "alpha", "provider"), []byte("test-provider"), 0600)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, "alpha", "test-secret-key"), []byte("test-secret-value"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "alpha", "type"), []byte("test-type"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "alpha", "provider"), []byte("test-provider"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "alpha", "test-secret-key"), []byte("test-secret-value"), 0600)).To(Succeed())
 
 			Expect(os.MkdirAll(filepath.Join(path, "bravo"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, "bravo", "type"), []byte("test-type"), 0600)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, "bravo", "provider"), []byte("test-provider"), 0600)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, "bravo", "test-secret-key"), []byte("test-secret-value"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "bravo", "type"), []byte("test-type"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "bravo", "provider"), []byte("test-provider"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, "bravo", "test-secret-key"), []byte("test-secret-value"), 0600)).To(Succeed())
 
 			Expect(os.MkdirAll(filepath.Join(path, ".hidden", "metadata"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, ".hidden", "metadata", "kind"), []byte("test-kind"), 0600)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(path, ".hiddenFile"), []byte("test-kind"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, ".hidden", "metadata", "kind"), []byte("test-kind"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(path, ".hiddenFile"), []byte("test-kind"), 0600)).To(Succeed())
 		})
 
 		context("Binding", func() {


### PR DESCRIPTION
ioutil is a deprecated package and there have been mappings of it's functionality to new standard library function since go 1.16. You can see all of those mappings on the [GoDocs page](https://pkg.go.dev/io/ioutil).