### PR TITLE
Adds layer.Reset function

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -156,6 +156,8 @@ func (l Layer) Reset() (Layer, error) {
 	l.SharedEnvironment = Environment{}
 	l.BuildEnvironment = Environment{}
 	l.LaunchEnvironment = Environment{}
+	l.Profile = Profile{}
+	l.Exec = Exec{Path: filepath.Join(l.Path, "exec.d")}
 	l.Metadata = nil
 
 	err := os.RemoveAll(l.Path)

--- a/layer.go
+++ b/layer.go
@@ -157,7 +157,6 @@ func (l Layer) Reset() (Layer, error) {
 	l.BuildEnvironment = Environment{}
 	l.LaunchEnvironment = Environment{}
 	l.Profile = Profile{}
-	l.Exec = Exec{Path: filepath.Join(l.Path, "exec.d")}
 	l.Metadata = nil
 
 	err := os.RemoveAll(l.Path)

--- a/layer.go
+++ b/layer.go
@@ -146,6 +146,31 @@ type Layer struct {
 	Exec Exec `toml:"-"`
 }
 
+func (l Layer) Reset() (Layer, error) {
+	l.LayerTypes = LayerTypes{
+		Build:  false,
+		Launch: false,
+		Cache:  false,
+	}
+
+	l.SharedEnvironment = Environment{}
+	l.BuildEnvironment = Environment{}
+	l.LaunchEnvironment = Environment{}
+	l.Metadata = nil
+
+	err := os.RemoveAll(l.Path)
+	if err != nil {
+		return Layer{}, fmt.Errorf("error could not remove file: %s", err)
+	}
+
+	err = os.MkdirAll(l.Path, os.ModePerm)
+	if err != nil {
+		return Layer{}, fmt.Errorf("error could not create directory: %s", err)
+	}
+
+	return l, nil
+}
+
 // SBOMPath returns the path to the layer specific SBOM File
 func (l Layer) SBOMPath(bt SBOMFormat) string {
 	return filepath.Join(filepath.Dir(l.Path), fmt.Sprintf("%s.sbom.%s", l.Name, bt))

--- a/layer_test.go
+++ b/layer_test.go
@@ -126,7 +126,6 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 					BuildEnvironment:  libcnb.Environment{},
 					LaunchEnvironment: libcnb.Environment{},
 					Profile:           libcnb.Profile{},
-					Exec:              libcnb.Exec{Path: filepath.Join(layers.Path, "test-name", "exec.d")},
 				}))
 
 				Expect(filepath.Join(layers.Path, "test-name")).To(BeADirectory())
@@ -181,7 +180,6 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 						"some-key": "some-value",
 					},
 					Profile: libcnb.Profile{"name": "value"},
-					Exec:    libcnb.Exec{Path: "something"},
 				}
 			})
 
@@ -202,7 +200,6 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 						BuildEnvironment:  libcnb.Environment{},
 						LaunchEnvironment: libcnb.Environment{},
 						Profile:           libcnb.Profile{},
-						Exec:              libcnb.Exec{Path: filepath.Join(layers.Path, "test-name", "exec.d")},
 					}))
 
 					Expect(filepath.Join(layers.Path, "test-name")).To(BeADirectory())

--- a/layer_test.go
+++ b/layer_test.go
@@ -125,6 +125,8 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 					SharedEnvironment: libcnb.Environment{},
 					BuildEnvironment:  libcnb.Environment{},
 					LaunchEnvironment: libcnb.Environment{},
+					Profile:           libcnb.Profile{},
+					Exec:              libcnb.Exec{Path: filepath.Join(layers.Path, "test-name", "exec.d")},
 				}))
 
 				Expect(filepath.Join(layers.Path, "test-name")).To(BeADirectory())
@@ -178,6 +180,8 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 					Metadata: map[string]interface{}{
 						"some-key": "some-value",
 					},
+					Profile: libcnb.Profile{"name": "value"},
+					Exec:    libcnb.Exec{Path: "something"},
 				}
 			})
 
@@ -197,6 +201,8 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 						SharedEnvironment: libcnb.Environment{},
 						BuildEnvironment:  libcnb.Environment{},
 						LaunchEnvironment: libcnb.Environment{},
+						Profile:           libcnb.Profile{},
+						Exec:              libcnb.Exec{Path: filepath.Join(layers.Path, "test-name", "exec.d")},
 					}))
 
 					Expect(filepath.Join(layers.Path, "test-name")).To(BeADirectory())


### PR DESCRIPTION
The `layer.Reset()` function is some functionality that exists in (`packit/v2` library)[https://github.com/paketo-buildpacks/packit/blob/7b9a5b045761a8d224580cdb904e5464fa0e8f8b/layer.go#L95-L117]. It allows a buildpack author to ensure that there is no data left over from a cached layer. I felt that it would be appropriate to add this functionality over here as well for authors who want to guarantee that their layers are empty.

Signed-off-by: Forest Eckhardt <feckhardt@pivotal.io>