### PR TITLE
Extract method for generating Config

### DIFF
--- a/build.go
+++ b/build.go
@@ -42,6 +42,9 @@ type BuildContext struct {
 	// Layers is the layers available to the buildpack.
 	Layers Layers
 
+	// Logger is the way to write messages to the end user
+	Logger Logger
+
 	// PersistentMetadata is metadata that is persisted even across cache cleaning.
 	PersistentMetadata map[string]interface{}
 
@@ -106,7 +109,7 @@ func (b BuildResult) String() string {
 }
 
 // BuildFunc takes a context and returns a result, performing buildpack build behaviors.
-type BuildFunc func(context BuildContext, logger Logger) (BuildResult, error)
+type BuildFunc func(context BuildContext) (BuildResult, error)
 
 // Build is called by the main function of a buildpack, for build.
 func Build(build BuildFunc, config Config) {
@@ -115,7 +118,7 @@ func Build(build BuildFunc, config Config) {
 		file string
 		ok   bool
 	)
-	ctx := BuildContext{}
+	ctx := BuildContext{Logger: config.logger}
 
 	ctx.ApplicationPath, err = os.Getwd()
 	if err != nil {
@@ -220,7 +223,7 @@ func Build(build BuildFunc, config Config) {
 	}
 	config.logger.Debugf("Stack: %s", ctx.StackID)
 
-	result, err := build(ctx, config.logger)
+	result, err := build(ctx)
 	if err != nil {
 		config.exitHandler.Error(err)
 		return

--- a/build_test.go
+++ b/build_test.go
@@ -56,7 +56,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.NewBuildResult(), nil
 		}
 
@@ -283,7 +283,7 @@ version = "1.1.1"
 				0600),
 			).To(Succeed())
 
-			buildFunc = func(context libcnb.BuildContext, _ libcnb.Logger) (libcnb.BuildResult, error) {
+			buildFunc = func(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 				ctx = context
 				return libcnb.NewBuildResult(), nil
 			}
@@ -348,7 +348,7 @@ version = "1.1.1"
 	})
 
 	it("handles error from BuildFunc", func() {
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.NewBuildResult(), errors.New("test-error")
 		}
 
@@ -363,7 +363,7 @@ version = "1.1.1"
 	})
 
 	it("writes env.build", func() {
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			layer := libcnb.Layer{Path: filepath.Join(layersPath, "test-name"), BuildEnvironment: libcnb.Environment{}}
 			layer.BuildEnvironment.Defaultf("test-build", "test-%s", "value")
 			return libcnb.BuildResult{Layers: []libcnb.Layer{layer}}, nil
@@ -381,7 +381,7 @@ version = "1.1.1"
 	})
 
 	it("writes env.launch", func() {
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			layer := libcnb.Layer{Path: filepath.Join(layersPath, "test-name"), LaunchEnvironment: libcnb.Environment{}}
 			layer.LaunchEnvironment.Defaultf("test-launch", "test-%s", "value")
 			return libcnb.BuildResult{Layers: []libcnb.Layer{layer}}, nil
@@ -399,7 +399,7 @@ version = "1.1.1"
 	})
 
 	it("writes env", func() {
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			layer := libcnb.Layer{Path: filepath.Join(layersPath, "test-name"), SharedEnvironment: libcnb.Environment{}}
 			layer.SharedEnvironment.Defaultf("test-shared", "test-%s", "value")
 			return libcnb.BuildResult{Layers: []libcnb.Layer{layer}}, nil
@@ -417,7 +417,7 @@ version = "1.1.1"
 	})
 
 	it("writes profile.d", func() {
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			layer := libcnb.Layer{Path: filepath.Join(layersPath, "test-name"), Profile: libcnb.Profile{}}
 			layer.Profile.Addf("test-profile", "test-%s", "value")
 			return libcnb.BuildResult{Layers: []libcnb.Layer{layer}}, nil
@@ -435,7 +435,7 @@ version = "1.1.1"
 	})
 
 	it("writes layer metadata", func() {
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			layer := libcnb.Layer{
 				Name: "test-name",
 				Path: filepath.Join(layersPath, "test-name"),
@@ -473,7 +473,7 @@ version = "1.1.1"
 
 		Expect(ioutil.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"), b.Bytes(), 0600)).To(Succeed())
 
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.BuildResult{
 				Layers: []libcnb.Layer{},
 				Processes: []libcnb.Process{
@@ -507,7 +507,7 @@ version = "1.1.1"
 	})
 
 	it("writes launch.toml", func() {
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.BuildResult{
 				Labels: []libcnb.Label{
 					{
@@ -563,7 +563,7 @@ version = "1.1.1"
 	it("writes persistent metadata", func() {
 		m := map[string]interface{}{"test-key": "test-value"}
 
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.BuildResult{PersistentMetadata: m}, nil
 		}
 
@@ -596,7 +596,7 @@ version = "1.1.1"
 
 		layer := libcnb.Layer{Name: "alpha"}
 
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.BuildResult{Layers: []libcnb.Layer{layer}}, nil
 		}
 
@@ -614,7 +614,7 @@ version = "1.1.1"
 	})
 
 	it("writes build.toml", func() {
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.BuildResult{
 				Unmet: []libcnb.UnmetPlanEntry{
 					{
@@ -656,7 +656,7 @@ sbom-formats = ["application/vnd.cyclonedx+json"]
 				0600),
 			).To(Succeed())
 
-			buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+			buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 				return libcnb.BuildResult{}, nil
 			}
 		})

--- a/build_test.go
+++ b/build_test.go
@@ -203,7 +203,7 @@ version = "1.1.1"
 
 		it("fails", func() {
 			libcnb.Build(buildFunc,
-				libcnb.NewConfigWithOptions(
+				libcnb.NewConfig(
 					libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 					libcnb.WithExitHandler(exitHandler),
 					libcnb.WithLogger(log.NewDiscard())),
@@ -242,7 +242,7 @@ version = "1.1.1"
 
 				it("fails", func() {
 					libcnb.Build(buildFunc,
-						libcnb.NewConfigWithOptions(
+						libcnb.NewConfig(
 							libcnb.WithArguments([]string{commandPath}),
 							libcnb.WithExitHandler(exitHandler)),
 					)
@@ -258,7 +258,7 @@ version = "1.1.1"
 		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -291,7 +291,7 @@ version = "1.1.1"
 
 		it("creates context", func() {
 			libcnb.Build(buildFunc,
-				libcnb.NewConfigWithOptions(
+				libcnb.NewConfig(
 					libcnb.WithArguments([]string{commandPath})),
 			)
 
@@ -338,7 +338,7 @@ version = "1.1.1"
 		Expect(os.Unsetenv("CNB_BUILDPACK_DIR")).To(Succeed())
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{filepath.Join(buildpackPath, commandPath), layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -353,7 +353,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -370,7 +370,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithEnvironmentWriter(environmentWriter),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -388,7 +388,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithEnvironmentWriter(environmentWriter),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -406,7 +406,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithEnvironmentWriter(environmentWriter),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -424,7 +424,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithEnvironmentWriter(environmentWriter),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -450,7 +450,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithTOMLWriter(tomlWriter),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -488,7 +488,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithTOMLWriter(tomlWriter)),
 		)
@@ -531,7 +531,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithTOMLWriter(tomlWriter),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -568,7 +568,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithTOMLWriter(tomlWriter),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -580,7 +580,7 @@ version = "1.1.1"
 
 	it("does not write empty files", func() {
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithTOMLWriter(tomlWriter),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -601,7 +601,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithTOMLWriter(tomlWriter),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -625,7 +625,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Build(buildFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 				libcnb.WithTOMLWriter(tomlWriter),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -663,7 +663,7 @@ sbom-formats = ["application/vnd.cyclonedx+json"]
 
 		it("has SBOM files", func() {
 			libcnb.Build(buildFunc,
-				libcnb.NewConfigWithOptions(
+				libcnb.NewConfig(
 					libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 					libcnb.WithExitHandler(exitHandler),
 					libcnb.WithLogger(log.NewDiscard())),
@@ -689,7 +689,7 @@ sbom-formats = []
 			Expect(os.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
 
 			libcnb.Build(buildFunc,
-				libcnb.NewConfigWithOptions(
+				libcnb.NewConfig(
 					libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 					libcnb.WithExitHandler(exitHandler),
 					libcnb.WithLogger(log.NewDiscard())),
@@ -702,7 +702,7 @@ sbom-formats = []
 			Expect(os.WriteFile(filepath.Join(layersPath, "launch.sbom.spdx.json"), []byte{}, 0600)).To(Succeed())
 
 			libcnb.Build(buildFunc,
-				libcnb.NewConfigWithOptions(
+				libcnb.NewConfig(
 					libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 					libcnb.WithExitHandler(exitHandler),
 					libcnb.WithLogger(log.NewDiscard())),
@@ -715,7 +715,7 @@ sbom-formats = []
 			Expect(os.WriteFile(filepath.Join(layersPath, "launch.sbom.cdx.json"), []byte{}, 0600)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(layersPath, "layer.sbom.cdx.json"), []byte{}, 0600)).To(Succeed())
 			libcnb.Build(buildFunc,
-				libcnb.NewConfigWithOptions(
+				libcnb.NewConfig(
 					libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 					libcnb.WithExitHandler(exitHandler),
 					libcnb.WithLogger(log.NewDiscard())),
@@ -728,7 +728,7 @@ sbom-formats = []
 			Expect(os.WriteFile(filepath.Join(layersPath, "launch.sbom.random.json"), []byte{}, 0600)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(layersPath, "layer.sbom.cdx.json"), []byte{}, 0600)).To(Succeed())
 			libcnb.Build(buildFunc,
-				libcnb.NewConfigWithOptions(
+				libcnb.NewConfig(
 					libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
 					libcnb.WithExitHandler(exitHandler),
 					libcnb.WithLogger(log.NewDiscard())),

--- a/config.go
+++ b/config.go
@@ -96,8 +96,8 @@ type Config struct {
 // Option is a function for configuring a Config instance.
 type Option func(config Config) Config
 
-// NewConfigWithOptions will generate a config from the given set of options
-func NewConfigWithOptions(options ...Option) Config {
+// NewConfig will generate a config from the given set of options
+func NewConfig(options ...Option) Config {
 	config := Config{}
 
 	// apply defaults

--- a/config.go
+++ b/config.go
@@ -16,6 +16,13 @@
 
 package libcnb
 
+import (
+	"os"
+
+	"github.com/buildpacks/libcnb/internal"
+	"github.com/buildpacks/libcnb/log"
+)
+
 //go:generate mockery --name EnvironmentWriter --case=underscore
 
 // EnvironmentWriter is the interface implemented by a type that wants to serialize a map of environment variables to
@@ -88,6 +95,26 @@ type Config struct {
 
 // Option is a function for configuring a Config instance.
 type Option func(config Config) Config
+
+// NewConfigWithOptions will generate a config from the given set of options
+func NewConfigWithOptions(options ...Option) Config {
+	config := Config{}
+
+	// apply defaults
+	options = append([]Option{
+		WithArguments(os.Args),
+		WithEnvironmentWriter(internal.EnvironmentWriter{}),
+		WithExitHandler(internal.NewExitHandler()),
+		WithLogger(log.New(os.Stdout)),
+		WithTOMLWriter(internal.TOMLWriter{}),
+	}, options...)
+
+	for _, opt := range options {
+		config = opt(config)
+	}
+
+	return config
+}
 
 // WithArguments creates an Option that sets a collection of arguments.
 func WithArguments(arguments []string) Option {

--- a/detect.go
+++ b/detect.go
@@ -38,6 +38,9 @@ type DetectContext struct {
 	// Buildpack is metadata about the buildpack, from buildpack.toml.
 	Buildpack Buildpack
 
+	// Logger is the way to write messages to the end user
+	Logger Logger
+
 	// Platform is the contents of the platform.
 	Platform Platform
 
@@ -56,7 +59,7 @@ type DetectResult struct {
 }
 
 // DetectFunc takes a context and returns a result, performing buildpack detect behaviors.
-type DetectFunc func(context DetectContext, logger Logger) (DetectResult, error)
+type DetectFunc func(context DetectContext) (DetectResult, error)
 
 // Detect is called by the main function of a buildpack, for detection.
 func Detect(detect DetectFunc, config Config) {
@@ -65,7 +68,7 @@ func Detect(detect DetectFunc, config Config) {
 		file string
 		ok   bool
 	)
-	ctx := DetectContext{}
+	ctx := DetectContext{Logger: config.logger}
 
 	ctx.ApplicationPath, err = os.Getwd()
 	if err != nil {
@@ -149,7 +152,7 @@ func Detect(detect DetectFunc, config Config) {
 	}
 	config.logger.Debugf("Stack: %s", ctx.StackID)
 
-	result, err := detect(ctx, config.logger)
+	result, err := detect(ctx)
 	if err != nil {
 		config.exitHandler.Error(err)
 		return

--- a/detect_test.go
+++ b/detect_test.go
@@ -97,7 +97,7 @@ test-key = "test-value"
 
 		commandPath = filepath.Join("bin", "detect")
 
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{}, nil
 		}
 
@@ -159,9 +159,10 @@ version = "1.1.1"
 
 		it("fails", func() {
 			libcnb.Detect(detectFunc,
-				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
-				libcnb.WithExitHandler(exitHandler),
-				libcnb.WithLogger(log.NewDiscard()),
+				libcnb.NewConfigWithOptions(
+					libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
+					libcnb.WithExitHandler(exitHandler),
+					libcnb.WithLogger(log.NewDiscard())),
 			)
 
 			if libcnb.MinSupportedBPVersion == libcnb.MaxSupportedBPVersion {
@@ -179,9 +180,10 @@ version = "1.1.1"
 		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
 
 		libcnb.Detect(detectFunc,
-			libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
-			libcnb.WithExitHandler(exitHandler),
-			libcnb.WithLogger(log.NewDiscard()),
+			libcnb.NewConfigWithOptions(
+				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+				libcnb.WithLogger(log.NewDiscard())),
 		)
 
 		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("CNB_STACK_ID not set"))
@@ -209,8 +211,9 @@ version = "1.1.1"
 
 				it("fails", func() {
 					libcnb.Detect(detectFunc,
-						libcnb.WithArguments([]string{commandPath}),
-						libcnb.WithExitHandler(exitHandler),
+						libcnb.NewConfigWithOptions(
+							libcnb.WithArguments([]string{commandPath}),
+							libcnb.WithExitHandler(exitHandler)),
 					)
 					Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(
 						fmt.Sprintf("expected %s to be set", envVar),
@@ -236,7 +239,7 @@ version = "1.1.1"
 				0600),
 			).To(Succeed())
 
-			detectFunc = func(context libcnb.DetectContext) (libcnb.DetectResult, error) {
+			detectFunc = func(context libcnb.DetectContext, logger libcnb.Logger) (libcnb.DetectResult, error) {
 				ctx = context
 				return libcnb.DetectResult{}, nil
 			}
@@ -244,8 +247,9 @@ version = "1.1.1"
 
 		it("creates context", func() {
 			libcnb.Detect(detectFunc,
-				libcnb.WithArguments([]string{commandPath}),
-				libcnb.WithExitHandler(exitHandler),
+				libcnb.NewConfigWithOptions(
+					libcnb.WithArguments([]string{commandPath}),
+					libcnb.WithExitHandler(exitHandler)),
 			)
 
 			Expect(ctx.ApplicationPath).To(Equal(applicationPath))
@@ -279,45 +283,48 @@ version = "1.1.1"
 		Expect(os.Unsetenv("CNB_BUILDPACK_DIR")).To(Succeed())
 
 		libcnb.Detect(detectFunc,
-			libcnb.WithArguments([]string{filepath.Join(buildpackPath, commandPath), platformPath, buildPlanPath}),
-			libcnb.WithExitHandler(exitHandler),
-			libcnb.WithLogger(log.NewDiscard()),
+			libcnb.NewConfigWithOptions(
+				libcnb.WithArguments([]string{filepath.Join(buildpackPath, commandPath), platformPath, buildPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+				libcnb.WithLogger(log.NewDiscard())),
 		)
 
 		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("unable to get CNB_BUILDPACK_DIR, not found"))
 	})
 
 	it("handles error from DetectFunc", func() {
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{}, fmt.Errorf("test-error")
 		}
 
 		libcnb.Detect(detectFunc,
-			libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
-			libcnb.WithExitHandler(exitHandler),
-			libcnb.WithLogger(log.NewDiscard()),
+			libcnb.NewConfigWithOptions(
+				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+				libcnb.WithLogger(log.NewDiscard())),
 		)
 
 		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("test-error"))
 	})
 
 	it("does not write empty files", func() {
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{Pass: true}, nil
 		}
 
 		libcnb.Detect(detectFunc,
-			libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
-			libcnb.WithExitHandler(exitHandler),
-			libcnb.WithTOMLWriter(tomlWriter),
-			libcnb.WithLogger(log.NewDiscard()),
+			libcnb.NewConfigWithOptions(
+				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+				libcnb.WithTOMLWriter(tomlWriter),
+				libcnb.WithLogger(log.NewDiscard())),
 		)
 
 		Expect(tomlWriter.Calls).To(HaveLen(0))
 	})
 
 	it("writes one build plan", func() {
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{
 				Pass: true,
 				Plans: []libcnb.BuildPlan{
@@ -337,10 +344,11 @@ version = "1.1.1"
 		}
 
 		libcnb.Detect(detectFunc,
-			libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
-			libcnb.WithExitHandler(exitHandler),
-			libcnb.WithTOMLWriter(tomlWriter),
-			libcnb.WithLogger(log.NewDiscard()),
+			libcnb.NewConfigWithOptions(
+				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+				libcnb.WithTOMLWriter(tomlWriter),
+				libcnb.WithLogger(log.NewDiscard())),
 		)
 
 		Expect(tomlWriter.Calls[0].Arguments.Get(0)).To(Equal(buildPlanPath))
@@ -360,7 +368,7 @@ version = "1.1.1"
 	})
 
 	it("writes two build plans", func() {
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{
 				Pass: true,
 				Plans: []libcnb.BuildPlan{
@@ -391,10 +399,11 @@ version = "1.1.1"
 		}
 
 		libcnb.Detect(detectFunc,
-			libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
-			libcnb.WithExitHandler(exitHandler),
-			libcnb.WithTOMLWriter(tomlWriter),
-			libcnb.WithLogger(log.NewDiscard()),
+			libcnb.NewConfigWithOptions(
+				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+				libcnb.WithTOMLWriter(tomlWriter),
+				libcnb.WithLogger(log.NewDiscard())),
 		)
 
 		Expect(tomlWriter.Calls[0].Arguments.Get(0)).To(Equal(buildPlanPath))

--- a/detect_test.go
+++ b/detect_test.go
@@ -97,7 +97,7 @@ test-key = "test-value"
 
 		commandPath = filepath.Join("bin", "detect")
 
-		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{}, nil
 		}
 
@@ -239,7 +239,7 @@ version = "1.1.1"
 				0600),
 			).To(Succeed())
 
-			detectFunc = func(context libcnb.DetectContext, logger libcnb.Logger) (libcnb.DetectResult, error) {
+			detectFunc = func(context libcnb.DetectContext) (libcnb.DetectResult, error) {
 				ctx = context
 				return libcnb.DetectResult{}, nil
 			}
@@ -293,7 +293,7 @@ version = "1.1.1"
 	})
 
 	it("handles error from DetectFunc", func() {
-		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{}, fmt.Errorf("test-error")
 		}
 
@@ -308,7 +308,7 @@ version = "1.1.1"
 	})
 
 	it("does not write empty files", func() {
-		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{Pass: true}, nil
 		}
 
@@ -324,7 +324,7 @@ version = "1.1.1"
 	})
 
 	it("writes one build plan", func() {
-		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{
 				Pass: true,
 				Plans: []libcnb.BuildPlan{
@@ -368,7 +368,7 @@ version = "1.1.1"
 	})
 
 	it("writes two build plans", func() {
-		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{
 				Pass: true,
 				Plans: []libcnb.BuildPlan{

--- a/detect_test.go
+++ b/detect_test.go
@@ -159,7 +159,7 @@ version = "1.1.1"
 
 		it("fails", func() {
 			libcnb.Detect(detectFunc,
-				libcnb.NewConfigWithOptions(
+				libcnb.NewConfig(
 					libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
 					libcnb.WithExitHandler(exitHandler),
 					libcnb.WithLogger(log.NewDiscard())),
@@ -180,7 +180,7 @@ version = "1.1.1"
 		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
 
 		libcnb.Detect(detectFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -211,7 +211,7 @@ version = "1.1.1"
 
 				it("fails", func() {
 					libcnb.Detect(detectFunc,
-						libcnb.NewConfigWithOptions(
+						libcnb.NewConfig(
 							libcnb.WithArguments([]string{commandPath}),
 							libcnb.WithExitHandler(exitHandler)),
 					)
@@ -247,7 +247,7 @@ version = "1.1.1"
 
 		it("creates context", func() {
 			libcnb.Detect(detectFunc,
-				libcnb.NewConfigWithOptions(
+				libcnb.NewConfig(
 					libcnb.WithArguments([]string{commandPath}),
 					libcnb.WithExitHandler(exitHandler)),
 			)
@@ -283,7 +283,7 @@ version = "1.1.1"
 		Expect(os.Unsetenv("CNB_BUILDPACK_DIR")).To(Succeed())
 
 		libcnb.Detect(detectFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{filepath.Join(buildpackPath, commandPath), platformPath, buildPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -298,7 +298,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Detect(detectFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 				libcnb.WithLogger(log.NewDiscard())),
@@ -313,7 +313,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Detect(detectFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 				libcnb.WithTOMLWriter(tomlWriter),
@@ -344,7 +344,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Detect(detectFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 				libcnb.WithTOMLWriter(tomlWriter),
@@ -399,7 +399,7 @@ version = "1.1.1"
 		}
 
 		libcnb.Detect(detectFunc,
-			libcnb.NewConfigWithOptions(
+			libcnb.NewConfig(
 				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
 				libcnb.WithExitHandler(exitHandler),
 				libcnb.WithTOMLWriter(tomlWriter),

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 
 // Main is called by the main function of a buildpack, encapsulating both detection and build in the same binary.
 func Main(detect DetectFunc, build BuildFunc, options ...Option) {
-	config := NewConfigWithOptions(options...)
+	config := NewConfig(options...)
 
 	if len(config.arguments) == 0 {
 		config.exitHandler.Error(fmt.Errorf("expected command name"))

--- a/main.go
+++ b/main.go
@@ -18,26 +18,12 @@ package libcnb
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
-
-	"github.com/buildpacks/libcnb/internal"
-	"github.com/buildpacks/libcnb/log"
 )
 
 // Main is called by the main function of a buildpack, encapsulating both detection and build in the same binary.
 func Main(detect DetectFunc, build BuildFunc, options ...Option) {
-	config := Config{
-		arguments:         os.Args,
-		environmentWriter: internal.EnvironmentWriter{},
-		exitHandler:       internal.NewExitHandler(),
-		logger:            log.New(os.Stdout),
-		tomlWriter:        internal.TOMLWriter{},
-	}
-
-	for _, option := range options {
-		config = option(config)
-	}
+	config := NewConfigWithOptions(options...)
 
 	if len(config.arguments) == 0 {
 		config.exitHandler.Error(fmt.Errorf("expected command name"))
@@ -46,9 +32,9 @@ func Main(detect DetectFunc, build BuildFunc, options ...Option) {
 
 	switch c := filepath.Base(config.arguments[0]); c {
 	case "build":
-		Build(build, options...)
+		Build(build, config)
 	case "detect":
-		Detect(detect, options...)
+		Detect(detect, config)
 	default:
 		config.exitHandler.Error(fmt.Errorf("unsupported command %s", c))
 		return

--- a/main_test.go
+++ b/main_test.go
@@ -56,7 +56,7 @@ func testMain(t *testing.T, context spec.G, it spec.S) {
 		applicationPath, err = filepath.EvalSymlinks(applicationPath)
 		Expect(err).NotTo(HaveOccurred())
 
-		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
 			return libcnb.NewBuildResult(), nil
 		}
 
@@ -107,7 +107,7 @@ test-key = "test-value"
 			0600),
 		).To(Succeed())
 
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{}, nil
 		}
 
@@ -203,7 +203,7 @@ test-key = "test-value"
 	})
 
 	it("calls detector for detect command", func() {
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{Pass: true}, nil
 		}
 		commandPath := filepath.Join("bin", "detect")
@@ -216,7 +216,7 @@ test-key = "test-value"
 	})
 
 	it("calls exitHandler.Pass() on detection pass", func() {
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{Pass: true}, nil
 		}
 		commandPath := filepath.Join("bin", "detect")
@@ -231,7 +231,7 @@ test-key = "test-value"
 	})
 
 	it("calls exitHandler.Fail() on detection fail", func() {
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{Pass: false}, nil
 		}
 		commandPath := filepath.Join("bin", "detect")

--- a/main_test.go
+++ b/main_test.go
@@ -56,7 +56,7 @@ func testMain(t *testing.T, context spec.G, it spec.S) {
 		applicationPath, err = filepath.EvalSymlinks(applicationPath)
 		Expect(err).NotTo(HaveOccurred())
 
-		buildFunc = func(libcnb.BuildContext, libcnb.Logger) (libcnb.BuildResult, error) {
+		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.NewBuildResult(), nil
 		}
 
@@ -107,7 +107,7 @@ test-key = "test-value"
 			0600),
 		).To(Succeed())
 
-		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{}, nil
 		}
 
@@ -203,7 +203,7 @@ test-key = "test-value"
 	})
 
 	it("calls detector for detect command", func() {
-		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{Pass: true}, nil
 		}
 		commandPath := filepath.Join("bin", "detect")
@@ -216,7 +216,7 @@ test-key = "test-value"
 	})
 
 	it("calls exitHandler.Pass() on detection pass", func() {
-		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{Pass: true}, nil
 		}
 		commandPath := filepath.Join("bin", "detect")
@@ -231,7 +231,7 @@ test-key = "test-value"
 	})
 
 	it("calls exitHandler.Fail() on detection fail", func() {
-		detectFunc = func(libcnb.DetectContext, libcnb.Logger) (libcnb.DetectResult, error) {
+		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{Pass: false}, nil
 		}
 		commandPath := filepath.Join("bin", "detect")


### PR DESCRIPTION
This PR extracts the code to create a Config object from a list of applied Options. The method also allows us to enforce a global set of default options.

I'm submitting this change for two reasons:

1. There was code duplicated across main/build/detect to generate a Config object. This change refactors that duplicate code out.
2. As a buildpack implementer, you will write your own BuildFunc/DetectFunc methods. These take a DetectContext/BuildContext as the single parameter. A buildpack author is going to want a logger. It may be that the author creates their own, but we are already asking the author to supply a libcnb.Logger implementation in their main build/detect method. This would essentially ask them to create two separate loggers. Instead, libcnb has the one provided to the main build/detect, we can just pass this dependency along though the DetectContext/BuildContext.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>