### PR TITLE
Use curl to install richgo

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -14,7 +14,19 @@ test:
 
       set -euo pipefail
 
-      GO111MODULE=on go get -u -ldflags="-s -w" github.com/kyoh86/richgo
+      echo "Installing richgo ${RICHGO_VERSION}"
+
+      mkdir -p "${HOME}"/bin
+      echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+      curl \
+        --location \
+        --show-error \
+        --silent \
+        "https://github.com/kyoh86/richgo/releases/download/v${RICHGO_VERSION}/richgo_${RICHGO_VERSION}_linux_amd64.tar.gz" \
+      | tar -C "${HOME}"/bin -xz richgo
+    env:
+      RICHGO_VERSION: 0.3.10
   - name: Run Tests
     run: |
       #!/usr/bin/env bash


### PR DESCRIPTION
This PR changes the workflow to use 'curl' to fetch and install richgo instead of 'go get'. We could switch to 'go install', but 'curl' is faster than fetching & building.

This is what the pipeline-builder project has been doing to install richgo for quite a while now.

This is required to get the tests passing on https://github.com/buildpacks/libcnb/pull/165.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>