### PR TITLE
Read bindings from VCAP_SERVICES 

### DIFF
--- a/platform_test.go
+++ b/platform_test.go
@@ -40,6 +40,57 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 		path = filepath.Join(platformPath, "bindings")
 	})
 
+	context("Cloudfoundry VCAP_SERVICES", func() {
+		context("Build", func() {
+			it("creates a bindings from VCAP_SERVICES", func() {
+				content, err := os.ReadFile("testdata/vcap_services.json")
+				Expect(err).NotTo(HaveOccurred())
+				t.Setenv(libcnb.EnvVcapServices, string(content))
+
+				bindings, err := libcnb.NewBindingsForBuild("")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(bindings).To(HaveLen(2))
+
+				types := []string{bindings[0].Type, bindings[1].Type}
+				Expect(types).To(ContainElements("elephantsql", "sendgrid"))
+			})
+
+			it("creates empty bindings from empty VCAP_SERVICES", func() {
+				t.Setenv(libcnb.EnvVcapServices, "{}")
+
+				bindings, err := libcnb.NewBindingsForBuild("")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(bindings).To(HaveLen(0))
+			})
+		})
+
+		context("Launch", func() {
+			it("creates a bindings from VCAP_SERVICES", func() {
+				content, err := os.ReadFile("testdata/vcap_services.json")
+				Expect(err).NotTo(HaveOccurred())
+				t.Setenv(libcnb.EnvVcapServices, string(content))
+
+				bindings, err := libcnb.NewBindingsForLaunch()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(bindings).To(HaveLen(2))
+				types := []string{bindings[0].Type, bindings[1].Type}
+				Expect(types).To(ContainElements("elephantsql", "sendgrid"))
+			})
+
+			it("creates empty bindings from empty VCAP_SERVICES", func() {
+				t.Setenv(libcnb.EnvVcapServices, "{}")
+
+				bindings, err := libcnb.NewBindingsForLaunch()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(bindings).To(HaveLen(0))
+			})
+		})
+	})
+
 	context("CNB Bindings", func() {
 		it.Before(func() {
 			Expect(os.MkdirAll(filepath.Join(path, "alpha", "metadata"), 0755)).To(Succeed())

--- a/testdata/vcap_services.json
+++ b/testdata/vcap_services.json
@@ -1,0 +1,44 @@
+{
+    "elephantsql": [
+      {
+        "name": "elephantsql-binding-c6c60",
+        "binding_guid": "44ceb72f-100b-4f50-87a2-7809c8b42b8d",
+        "binding_name": "elephantsql-binding-c6c60",
+        "instance_guid": "391308e8-8586-4c42-b464-c7831aa2ad22",
+        "instance_name": "elephantsql-c6c60",
+        "label": "elephantsql",
+        "tags": [
+          "postgres",
+          "postgresql",
+          "relational"
+        ],
+        "plan": "turtle",
+        "credentials": {
+          "uri": "postgres://exampleuser:examplepass@postgres.example.com:5432/exampleuser"
+        },
+        "syslog_drain_url": null,
+        "volume_mounts": []
+      }
+    ],
+    "sendgrid": [
+      {
+        "name": "mysendgrid",
+        "binding_guid": "6533b1b6-7916-488d-b286-ca33d3fa0081",
+        "binding_name": null,
+        "instance_guid": "8c907d0f-ec0f-44e4-87cf-e23c9ba3925d",
+        "instance_name": "mysendgrid",
+        "label": "sendgrid",
+        "tags": [
+          "smtp"
+        ],
+        "plan": "free",
+        "credentials": {
+          "hostname": "smtp.example.com",
+          "username": "QvsXMbJ3rK",
+          "password": "HCHMOYluTv"
+        },
+        "syslog_drain_url": null,
+        "volume_mounts": []
+      }
+    ]
+}


### PR DESCRIPTION
Buildpacks like https://github.com/paketo-buildpacks/dynatrace need specific bindings (e.g. credentials to download assets). If the bindings are not only read from the file system, but from the env variable `VCAP_SERVICES`, those buildpacks could be used not only on kubernetes, but also on cloudfoundry.

Backport of #227 