### PR TITLE
Fix unit test: do not rely on the order of the binding

### DIFF
--- a/platform_test.go
+++ b/platform_test.go
@@ -56,8 +56,8 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(bindings).To(HaveLen(2))
-			Expect(bindings[0].Type).To(Equal("elephantsql"))
-			Expect(bindings[1].Type).To(Equal("sendgrid"))
+			types := []string{bindings[0].Type, bindings[1].Type}
+			Expect(types).To(ContainElements("elephantsql", "sendgrid"))
 		})
 
 		it("creates empty bindings from empty VCAP_SERVICES", func() {


### PR DESCRIPTION
Fix unit test: do not rely on the order of the bindings extracted from… VCAP_SERVICES

see also #228 
see [comment](https://github.com/buildpacks/libcnb/pull/228#issuecomment-1534926379)