### PR TITLE
Add extension support

### DIFF
--- a/config.go
+++ b/config.go
@@ -79,6 +79,7 @@ type Config struct {
 	logger              log.Logger
 	tomlWriter          TOMLWriter
 	contentWriter       internal.DirectoryContentsWriter
+	extension           bool
 }
 
 // Option is a function for configuring a Config instance.

--- a/detect.go
+++ b/detect.go
@@ -36,10 +36,10 @@ type DetectContext struct {
 	// the lifecycle.
 	ApplicationPath string
 
-	// Buildpack is metadata about the buildpack from buildpack.toml
+	// Buildpack is metadata about the buildpack from buildpack.toml (empty when processing an extension)
 	Buildpack Buildpack
 
-	// Buildpack is metadata about the buildpack from buildpack.toml
+	// Extension is metadata about the extension from extension.toml (empty when processing a buildpack)
 	Extension Extension
 
 	// Logger is the way to write messages to the end user

--- a/example_build_test.go
+++ b/example_build_test.go
@@ -93,7 +93,8 @@ func (b Builder) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) 
 }
 
 func ExampleBuild() {
-	detetector := Detector{log.New(os.Stdout)}
+	detector := Detector{log.New(os.Stdout)}
 	builder := Builder{log.New(os.Stdout)}
-	libcnb.Main(detetector.Detect, builder.Build)
+	generator := Generator{log.New(os.Stdout)}
+	libcnb.Main(detector.Detect, builder.Build, generator.Generate)
 }

--- a/example_build_test.go
+++ b/example_build_test.go
@@ -95,6 +95,5 @@ func (b Builder) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) 
 func ExampleBuild() {
 	detector := Detector{log.New(os.Stdout)}
 	builder := Builder{log.New(os.Stdout)}
-	generator := Generator{log.New(os.Stdout)}
-	libcnb.Main(detector.Detect, builder.Build, generator.Generate)
+	libcnb.BuildpackMain(detector.Detect, builder.Build)
 }

--- a/example_detect_test.go
+++ b/example_detect_test.go
@@ -63,5 +63,5 @@ func (Detector) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 
 func ExampleDetect() {
 	detector := Detector{log.New(os.Stdout)}
-	libcnb.Main(detector.Detect, nil)
+	libcnb.Main(detector.Detect, nil, nil)
 }

--- a/example_detect_test.go
+++ b/example_detect_test.go
@@ -63,5 +63,5 @@ func (Detector) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 
 func ExampleDetect() {
 	detector := Detector{log.New(os.Stdout)}
-	libcnb.Main(detector.Detect, nil, nil)
+	libcnb.BuildpackMain(detector.Detect, nil)
 }

--- a/example_generate_test.go
+++ b/example_generate_test.go
@@ -1,6 +1,7 @@
 package libcnb_test
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/buildpacks/libcnb"
@@ -12,14 +13,18 @@ type Generator struct {
 }
 
 func (Generator) Generate(context libcnb.GenerateContext) (libcnb.GenerateResult, error) {
-	//here you can read the context.ApplicationPath folder
-	//and create run.Dockerfile and build.Dockerfile in the context.OutputPath folder
-	//and read metadata from the context.Extension struct
+	// here you can read the context.ApplicationPath folder
+	// and create run.Dockerfile and build.Dockerfile in the context.OutputPath folder
+	// and read metadata from the context.Extension struct
+
+	// Just to use context to keep compiler happy =)
+	fmt.Println(context.Extension.Info.ID)
+
 	result := libcnb.NewGenerateResult()
 	return result, nil
 }
 
-func ExampleGeneratre() {
+func ExampleGenerate() {
 	generator := Generator{log.New(os.Stdout)}
 	libcnb.ExtensionMain(nil, generator.Generate)
 }

--- a/example_generate_test.go
+++ b/example_generate_test.go
@@ -21,5 +21,5 @@ func (Generator) Generate(context libcnb.GenerateContext) (libcnb.GenerateResult
 
 func ExampleGeneratre() {
 	generator := Generator{log.New(os.Stdout)}
-	libcnb.Main(nil, nil, generator.Generate)
+	libcnb.ExtensionMain(nil, generator.Generate)
 }

--- a/example_generate_test.go
+++ b/example_generate_test.go
@@ -1,0 +1,25 @@
+package libcnb_test
+
+import (
+	"os"
+
+	"github.com/buildpacks/libcnb"
+	"github.com/buildpacks/libcnb/log"
+)
+
+type Generator struct {
+	Logger log.Logger
+}
+
+func (Generator) Generate(context libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+	//here you can read the context.ApplicationPath folder
+	//and create run.Dockerfile and build.Dockerfile in the context.OutputPath folder
+	//and read metadata from the context.Extension struct
+	result := libcnb.NewGenerateResult()
+	return result, nil
+}
+
+func ExampleGeneratre() {
+	generator := Generator{log.New(os.Stdout)}
+	libcnb.Main(nil, nil, generator.Generate)
+}

--- a/extension.go
+++ b/extension.go
@@ -46,9 +46,6 @@ type Extension struct {
 	API string `toml:"api"`
 
 	// Info is information about the extension.
-	// The format is the same as the BuildpackInfo today
-	// it's beneficial to leave the type the same for now, to allow
-	// passing it to places that expect a BuildpackInfo
 	Info ExtensionInfo `toml:"extension"`
 
 	// Path is the path to the extension.

--- a/extension.go
+++ b/extension.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libcnb
+
+// ExtensionInfo is information about the extension.
+type ExtensionInfo struct {
+	// ID is the ID of the extension.
+	ID string `toml:"id"`
+
+	// Name is the name of the extension.
+	Name string `toml:"name"`
+
+	// Version is the version of the extension.
+	Version string `toml:"version"`
+
+	// Homepage is the homepage of the extension.
+	Homepage string `toml:"homepage"`
+
+	// Description is a string describing the extension.
+	Description string `toml:"description"`
+
+	// Keywords is a list of words that are associated with the extension.
+	Keywords []string `toml:"keywords"`
+
+	// Licenses a list of extension licenses.
+	Licenses []License `toml:"licenses"`
+}
+
+// Extension is the contents of the extension.toml file.
+type Extension struct {
+	// API is the api version expected by the extension.
+	API string `toml:"api"`
+
+	// Info is information about the extension.
+	// The format is the same as the BuildpackInfo today
+	// it's beneficial to leave the type the same for now, to allow
+	// passing it to places that expect a BuildpackInfo
+	Info ExtensionInfo `toml:"extension"`
+
+	// Path is the path to the extension.
+	Path string `toml:"-"`
+
+	// Metadata is arbitrary metadata attached to the extension.
+	Metadata map[string]interface{} `toml:"metadata"`
+}

--- a/extension_test.go
+++ b/extension_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libcnb_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/sclevine/spec"
+
+	"github.com/buildpacks/libcnb"
+
+	. "github.com/onsi/gomega"
+)
+
+func testExtensionTOML(t *testing.T, _ spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+	)
+
+	it("does not serialize the Path field", func() {
+		extn := libcnb.Extension{
+			API: "0.8",
+			Info: libcnb.ExtensionInfo{
+				ID:   "test-buildpack/sample",
+				Name: "sample",
+			},
+			Path: "../buildpack",
+		}
+
+		output := &bytes.Buffer{}
+
+		Expect(toml.NewEncoder(output).Encode(extn)).To(Succeed())
+		Expect(output.String()).NotTo(Or(ContainSubstring("Path = "), ContainSubstring("path = ")))
+	})
+}

--- a/generate.go
+++ b/generate.go
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libcnb
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/Masterminds/semver"
+
+	"github.com/buildpacks/libcnb/internal"
+	"github.com/buildpacks/libcnb/log"
+)
+
+// GenerateContext contains the inputs to generate.
+type GenerateContext struct {
+	// ApplicationPath is the location of the application source code as provided by
+	// the lifecycle.
+	ApplicationPath string
+
+	// Extension is metadata about the extension, from extension.toml.
+	Extension Extension
+
+	// OutputDirectory is the location Dockerfiles should be written to.
+	OutputDirectory string
+
+	// Logger is the way to write messages to the end user
+	Logger log.Logger
+
+	// Plan is the buildpack plan provided to the buildpack.
+	Plan BuildpackPlan
+
+	// Platform is the contents of the platform.
+	Platform Platform
+
+	// StackID is the ID of the stack.
+	StackID string
+}
+
+// GenerateResult contains the results of detection.
+type GenerateResult struct {
+	// Unmet contains buildpack plan entries that were not satisfied by the buildpack and therefore should be
+	// passed to subsequent providers.
+	Unmet []UnmetPlanEntry
+}
+
+// NewBuildResult creates a new BuildResult instance, initializing empty fields.
+func NewGenerateResult() GenerateResult {
+	return GenerateResult{}
+}
+
+func (b GenerateResult) String() string {
+	return fmt.Sprintf(
+		"{Unmet:%+v}",
+		b.Unmet,
+	)
+}
+
+// BuildFunc takes a context and returns a result, performing extension generate behaviors.
+type GenerateFunc func(context GenerateContext) (GenerateResult, error)
+
+// Generate is called by the main function of a extension, for generate phase
+func Generate(generate GenerateFunc, config Config) {
+	var (
+		err  error
+		file string
+		ok   bool
+	)
+	ctx := GenerateContext{Logger: config.logger}
+
+	ctx.ApplicationPath, err = os.Getwd()
+	if err != nil {
+		config.exitHandler.Error(fmt.Errorf("unable to get working directory\n%w", err))
+		return
+	}
+
+	if config.logger.IsDebugEnabled() {
+		if err := config.contentWriter.Write("Application contents", ctx.ApplicationPath); err != nil {
+			config.logger.Debugf("unable to write application contents\n%w", err)
+		}
+	}
+
+	if s, ok := os.LookupEnv(EnvExtensionDirectory); ok {
+		ctx.Extension.Path = filepath.Clean(s)
+	} else {
+		config.exitHandler.Error(fmt.Errorf("unable to get CNB_EXTENSION_DIR, not found"))
+		return
+	}
+
+	if config.logger.IsDebugEnabled() {
+		if err := config.contentWriter.Write("Extension contents", ctx.Extension.Path); err != nil {
+			config.logger.Debugf("unable to write extension contents\n%w", err)
+		}
+	}
+
+	file = filepath.Join(ctx.Extension.Path, "extension.toml")
+	if _, err = toml.DecodeFile(file, &ctx.Extension); err != nil && !os.IsNotExist(err) {
+		config.exitHandler.Error(fmt.Errorf("unable to decode extension %s\n%w", file, err))
+		return
+	}
+	config.logger.Debugf("Extension: %+v", ctx.Extension)
+
+	API, err := semver.NewVersion(ctx.Extension.API)
+	if err != nil {
+		config.exitHandler.Error(errors.New("version cannot be parsed"))
+		return
+	}
+
+	compatVersionCheck, _ := semver.NewConstraint(fmt.Sprintf(">= %s, <= %s", MinSupportedBPVersion, MaxSupportedBPVersion))
+	if !compatVersionCheck.Check(API) {
+		if MinSupportedBPVersion == MaxSupportedBPVersion {
+			config.exitHandler.Error(fmt.Errorf("this version of libcnb is only compatible with buildpack API == %s", MinSupportedBPVersion))
+			return
+		}
+
+		config.exitHandler.Error(fmt.Errorf("this version of libcnb is only compatible with buildpack APIs >= %s, <= %s", MinSupportedBPVersion, MaxSupportedBPVersion))
+		return
+	}
+
+	outputDir, ok := os.LookupEnv(EnvOutputDirectory)
+	if !ok {
+		config.exitHandler.Error(fmt.Errorf("expected CNB_OUTPUT_DIR to be set"))
+		return
+	}
+	ctx.OutputDirectory = outputDir
+
+	ctx.Platform.Path, ok = os.LookupEnv(EnvPlatformDirectory)
+	if !ok {
+		config.exitHandler.Error(fmt.Errorf("expected CNB_PLATFORM_DIR to be set"))
+		return
+	}
+
+	buildpackPlanPath, ok := os.LookupEnv(EnvBuildPlanPath)
+	if !ok {
+		config.exitHandler.Error(fmt.Errorf("expected CNB_BP_PLAN_PATH to be set"))
+		return
+	}
+
+	if config.logger.IsDebugEnabled() {
+		if err := config.contentWriter.Write("Platform contents", ctx.Platform.Path); err != nil {
+			config.logger.Debugf("unable to write platform contents\n%w", err)
+		}
+	}
+
+	if ctx.Platform.Bindings, err = NewBindings(ctx.Platform.Path); err != nil {
+		config.exitHandler.Error(fmt.Errorf("unable to read platform bindings %s\n%w", ctx.Platform.Path, err))
+		return
+	}
+	config.logger.Debugf("Platform Bindings: %+v", ctx.Platform.Bindings)
+
+	file = filepath.Join(ctx.Platform.Path, "env")
+	if ctx.Platform.Environment, err = internal.NewConfigMapFromPath(file); err != nil {
+		config.exitHandler.Error(fmt.Errorf("unable to read platform environment %s\n%w", file, err))
+		return
+	}
+	config.logger.Debugf("Platform Environment: %s", ctx.Platform.Environment)
+
+	if _, err = toml.DecodeFile(buildpackPlanPath, &ctx.Plan); err != nil && !os.IsNotExist(err) {
+		config.exitHandler.Error(fmt.Errorf("unable to decode buildpack plan %s\n%w", buildpackPlanPath, err))
+		return
+	}
+	config.logger.Debugf("Buildpack Plan: %+v", ctx.Plan)
+
+	if ctx.StackID, ok = os.LookupEnv(EnvStackID); !ok {
+		config.exitHandler.Error(fmt.Errorf("CNB_STACK_ID not set"))
+		return
+	}
+	config.logger.Debugf("Stack: %s", ctx.StackID)
+
+	result, err := generate(ctx)
+	if err != nil {
+		config.exitHandler.Error(err)
+		return
+	}
+	config.logger.Debugf("Result: %+v", result)
+}

--- a/generate_test.go
+++ b/generate_test.go
@@ -356,4 +356,5 @@ version = "1.1.1"
 
 		Expect(filepath.Join(outputPath, "build.Dockerfile")).To(BeARegularFile())
 	})
+
 }

--- a/generate_test.go
+++ b/generate_test.go
@@ -356,5 +356,4 @@ version = "1.1.1"
 
 		Expect(filepath.Join(outputPath, "build.Dockerfile")).To(BeARegularFile())
 	})
-
 }

--- a/generate_test.go
+++ b/generate_test.go
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2018-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libcnb_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	. "github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/buildpacks/libcnb"
+	"github.com/buildpacks/libcnb/log"
+	"github.com/buildpacks/libcnb/mocks"
+)
+
+func testGenerate(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		generateFunc      libcnb.GenerateFunc
+		applicationPath   string
+		extensionPath     string
+		outputPath        string
+		buildpackPlanPath string
+		extnTOMLContents  string
+		commandPath       string
+		environmentWriter *mocks.EnvironmentWriter
+		exitHandler       *mocks.ExitHandler
+		platformPath      string
+		tomlWriter        *mocks.TOMLWriter
+		extensionTOML     *template.Template
+
+		workingDir string
+	)
+
+	it.Before(func() {
+		generateFunc = func(libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+			return libcnb.NewGenerateResult(), nil
+		}
+
+		var err error
+		applicationPath, err = os.MkdirTemp("", "generate-application-path")
+		Expect(err).NotTo(HaveOccurred())
+		applicationPath, err = filepath.EvalSymlinks(applicationPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		extensionPath, err = os.MkdirTemp("", "generate-extension-path")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Setenv("CNB_EXTENSION_DIR", extensionPath)).To(Succeed())
+
+		extnTOMLContents = `
+api = "{{.APIVersion}}"
+
+[extension]
+id = "test-id"
+name = "test-name"
+version = "1.1.1"
+description = "A test buildpack"
+keywords = ["test", "buildpack"]
+
+[[extension.licenses]]
+type = "Apache-2.0"
+uri = "https://spdx.org/licenses/Apache-2.0.html"
+
+[[extension.licenses]]
+type = "Apache-1.1"
+uri = "https://spdx.org/licenses/Apache-1.1.html"
+
+[metadata]
+test-key = "test-value"
+`
+		extensionTOML, err = template.New("extension.toml").Parse(extnTOMLContents)
+		Expect(err).ToNot(HaveOccurred())
+
+		var b bytes.Buffer
+		err = extensionTOML.Execute(&b, map[string]string{"APIVersion": "0.8"})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(os.WriteFile(filepath.Join(extensionPath, "extension.toml"), b.Bytes(), 0600)).To(Succeed())
+
+		f, err := os.CreateTemp("", "generate-buildpackplan-path")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(f.Close()).NotTo(HaveOccurred())
+		buildpackPlanPath = f.Name()
+
+		Expect(os.WriteFile(buildpackPlanPath,
+			[]byte(`
+[[entries]]
+name = "test-name"
+version = "test-version"
+
+[entries.metadata]
+test-key = "test-value"
+`),
+			0600),
+		).To(Succeed())
+
+		commandPath = filepath.Join("bin", "generate")
+
+		environmentWriter = &mocks.EnvironmentWriter{}
+		environmentWriter.On("Write", mock.Anything, mock.Anything).Return(nil)
+
+		exitHandler = &mocks.ExitHandler{}
+		exitHandler.On("Error", mock.Anything)
+
+		platformPath, err = os.MkdirTemp("", "generate-platform-path")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(os.MkdirAll(filepath.Join(platformPath, "bindings", "alpha"), 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(platformPath, "bindings", "alpha", "test-secret-key"),
+			[]byte("test-secret-value"), 0600)).To(Succeed())
+
+		Expect(os.MkdirAll(filepath.Join(platformPath, "env"), 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(platformPath, "env", "TEST_ENV"), []byte("test-value"), 0600)).
+			To(Succeed())
+
+		tomlWriter = &mocks.TOMLWriter{}
+		tomlWriter.On("Write", mock.Anything, mock.Anything).Return(nil)
+
+		outputPath, err = os.MkdirTemp("", "generate-output-path")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Setenv("CNB_OUTPUT_DIR", outputPath)).To(Succeed())
+
+		Expect(os.Setenv("CNB_STACK_ID", "test-stack-id")).To(Succeed())
+
+		Expect(os.Setenv("CNB_PLATFORM_DIR", platformPath)).To(Succeed())
+		Expect(os.Setenv("CNB_BP_PLAN_PATH", buildpackPlanPath)).To(Succeed())
+
+		workingDir, err = os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Chdir(applicationPath)).To(Succeed())
+	})
+
+	it.After(func() {
+		Expect(os.Chdir(workingDir)).To(Succeed())
+		Expect(os.Unsetenv("CNB_EXTENSION_DIR")).To(Succeed())
+		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
+		Expect(os.Unsetenv("CNB_PLATFORM_DIR")).To(Succeed())
+		Expect(os.Unsetenv("CNB_BP_PLAN_PATH")).To(Succeed())
+		Expect(os.Unsetenv("CNB_OUTPUT_DIR")).To(Succeed())
+
+		Expect(os.RemoveAll(applicationPath)).To(Succeed())
+		Expect(os.RemoveAll(extensionPath)).To(Succeed())
+		Expect(os.RemoveAll(buildpackPlanPath)).To(Succeed())
+		Expect(os.RemoveAll(outputPath)).To(Succeed())
+		Expect(os.RemoveAll(platformPath)).To(Succeed())
+	})
+
+	context("buildpack API is not within the supported range", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(extensionPath, "extension.toml"),
+				[]byte(`
+api = "0.7"
+
+[extension]
+id = "test-id"
+name = "test-name"
+version = "1.1.1"
+`),
+				0600),
+			).To(Succeed())
+		})
+
+		it("fails", func() {
+			libcnb.Generate(generateFunc,
+				libcnb.NewConfig(
+					libcnb.WithArguments([]string{commandPath, outputPath, platformPath, buildpackPlanPath}),
+					libcnb.WithExitHandler(exitHandler),
+					libcnb.WithLogger(log.NewDiscard())),
+			)
+
+			if libcnb.MinSupportedBPVersion == libcnb.MaxSupportedBPVersion {
+				Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(
+					fmt.Sprintf("this version of libcnb is only compatible with buildpack API == %s", libcnb.MinSupportedBPVersion)))
+			} else {
+				Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(
+					fmt.Sprintf("this version of libcnb is only compatible with buildpack APIs >= %s, <= %s", libcnb.MinSupportedBPVersion, libcnb.MaxSupportedBPVersion),
+				))
+			}
+		})
+	})
+
+	context("errors if required env vars are not set", func() {
+		for _, e := range []string{"CNB_OUTPUT_DIR", "CNB_PLATFORM_DIR", "CNB_BP_PLAN_PATH"} {
+			// We need to do this assignment because of the way that spec binds variables
+			envVar := e
+			context(fmt.Sprintf("when %s is unset", envVar), func() {
+				it.Before(func() {
+					Expect(os.WriteFile(filepath.Join(extensionPath, "extension.toml"),
+						[]byte(`
+		api = "0.8"
+
+		[extension]
+		id = "test-id"
+		name = "test-name"
+		version = "1.1.1"
+		`),
+						0600),
+					).To(Succeed())
+					os.Unsetenv(envVar)
+				})
+
+				it("fails", func() {
+					libcnb.Generate(generateFunc,
+						libcnb.NewConfig(
+							libcnb.WithArguments([]string{commandPath}),
+							libcnb.WithExitHandler(exitHandler)),
+					)
+					Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError(
+						fmt.Sprintf("expected %s to be set", envVar),
+					))
+				})
+			})
+		}
+	})
+
+	it("doesn't receive CNB_STACK_ID", func() {
+		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
+
+		libcnb.Generate(generateFunc,
+			libcnb.NewConfig(
+				libcnb.WithArguments([]string{commandPath, outputPath, platformPath, buildpackPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+				libcnb.WithLogger(log.NewDiscard())),
+		)
+
+		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("CNB_STACK_ID not set"))
+	})
+
+	context("has a build environment", func() {
+		var ctx libcnb.GenerateContext
+
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(extensionPath, "extension.toml"),
+				[]byte(`
+	api = "0.8"
+	
+	[extension]
+	id = "test-id"
+	name = "test-name"
+	version = "1.1.1"
+	`),
+				0600),
+			).To(Succeed())
+
+			generateFunc = func(context libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+				ctx = context
+				return libcnb.NewGenerateResult(), nil
+			}
+		})
+
+		it("creates context", func() {
+			libcnb.Generate(generateFunc,
+				libcnb.NewConfig(
+					libcnb.WithArguments([]string{commandPath})),
+			)
+			Expect(ctx.ApplicationPath).To(Equal(applicationPath))
+			Expect(ctx.Extension).To(Equal(libcnb.Extension{
+				API: "0.8",
+				Info: libcnb.ExtensionInfo{
+					ID:      "test-id",
+					Name:    "test-name",
+					Version: "1.1.1",
+				},
+				Path: extensionPath,
+			}))
+			Expect(ctx.OutputDirectory).To(Equal(outputPath))
+			Expect(ctx.Plan).To(Equal(libcnb.BuildpackPlan{
+				Entries: []libcnb.BuildpackPlanEntry{
+					{
+						Name: "test-name",
+						Metadata: map[string]interface{}{
+							"test-key": "test-value",
+						},
+					},
+				},
+			}))
+			Expect(ctx.Platform).To(Equal(libcnb.Platform{
+				Bindings: libcnb.Bindings{
+					libcnb.Binding{
+						Name: "alpha",
+						Path: filepath.Join(platformPath, "bindings", "alpha"),
+						Secret: map[string]string{
+							"test-secret-key": "test-secret-value",
+						},
+					},
+				},
+				Environment: map[string]string{"TEST_ENV": "test-value"},
+				Path:        platformPath,
+			}))
+			Expect(ctx.StackID).To(Equal("test-stack-id"))
+		})
+	})
+
+	it("fails if CNB_EXTENSION_DIR is not set", func() {
+		Expect(os.Unsetenv("CNB_EXTENSION_DIR")).To(Succeed())
+
+		libcnb.Generate(generateFunc,
+			libcnb.NewConfig(
+				libcnb.WithArguments([]string{filepath.Join(extensionPath, commandPath), outputPath, platformPath, buildpackPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+				libcnb.WithLogger(log.NewDiscard())),
+		)
+
+		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("unable to get CNB_EXTENSION_DIR, not found"))
+	})
+
+	it("handles error from GenerateFunc", func() {
+		generateFunc = func(libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+			return libcnb.NewGenerateResult(), errors.New("test-error")
+		}
+
+		libcnb.Generate(generateFunc,
+			libcnb.NewConfig(
+				libcnb.WithArguments([]string{commandPath, outputPath, platformPath, buildpackPlanPath}),
+				libcnb.WithExitHandler(exitHandler),
+				libcnb.WithLogger(log.NewDiscard())),
+		)
+
+		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("test-error"))
+	})
+
+	it("writes a Dockerfile", func() {
+		generateFunc = func(ctx libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+			os.WriteFile(filepath.Join(ctx.OutputDirectory, "build.Dockerfile"), []byte(""), 0600)
+			return libcnb.NewGenerateResult(), nil
+		}
+
+		libcnb.Generate(generateFunc,
+			libcnb.NewConfig(
+				libcnb.WithArguments([]string{commandPath, outputPath, platformPath, buildpackPlanPath}),
+				libcnb.WithTOMLWriter(tomlWriter),
+				libcnb.WithLogger(log.NewDiscard())),
+		)
+
+		Expect(filepath.Join(outputPath, "build.Dockerfile")).To(BeARegularFile())
+	})
+
+}

--- a/init_test.go
+++ b/init_test.go
@@ -27,11 +27,13 @@ func TestUnit(t *testing.T) {
 	suite := spec.New("libcnb", spec.Report(report.Terminal{}))
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
+	suite("Generate", testGenerate)
 	suite("Environment", testEnvironment)
 	suite("Layer", testLayer)
 	suite("Main", testMain)
 	suite("Platform", testPlatform)
 	suite("ExecD", testExecD)
 	suite("BuildpackTOML", testBuildpackTOML)
+	suite("ExtensionTOML", testExtensionTOML)
 	suite.Run(t)
 }

--- a/main.go
+++ b/main.go
@@ -21,8 +21,7 @@ import (
 	"path/filepath"
 )
 
-// Main is called by the main function of a buildpack, encapsulating both detection and build in the same binary.
-func Main(detect DetectFunc, build BuildFunc, generate GenerateFunc, options ...Option) {
+func main(detect DetectFunc, build BuildFunc, generate GenerateFunc, options ...Option) {
 	config := NewConfig(options...)
 
 	if len(config.arguments) == 0 {
@@ -41,4 +40,14 @@ func Main(detect DetectFunc, build BuildFunc, generate GenerateFunc, options ...
 		config.exitHandler.Error(fmt.Errorf("unsupported command %s", c))
 		return
 	}
+}
+
+// BuildpackMain is called by the main function of a buildpack, encapsulating both detection and build in the same binary.
+func BuildpackMain(detect DetectFunc, build BuildFunc, options ...Option) {
+	main(detect, build, nil, options...)
+}
+
+// ExtensionMain is called by the main function of a extension, encapsulating both detection and generation in the same binary.
+func ExtensionMain(detect DetectFunc, generate GenerateFunc, options ...Option) {
+	main(detect, nil, generate, options...)
 }

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import (
 )
 
 // Main is called by the main function of a buildpack, encapsulating both detection and build in the same binary.
-func Main(detect DetectFunc, build BuildFunc, options ...Option) {
+func Main(detect DetectFunc, build BuildFunc, generate GenerateFunc, options ...Option) {
 	config := NewConfig(options...)
 
 	if len(config.arguments) == 0 {
@@ -35,6 +35,8 @@ func Main(detect DetectFunc, build BuildFunc, options ...Option) {
 		Build(build, config)
 	case "detect":
 		Detect(detect, config)
+	case "generate":
+		Generate(generate, config)
 	default:
 		config.exitHandler.Error(fmt.Errorf("unsupported command %s", c))
 		return

--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ func main(detect DetectFunc, build BuildFunc, generate GenerateFunc, options ...
 		return
 	}
 
+	config.extension = build == nil && generate != nil
+
 	switch c := filepath.Base(config.arguments[0]); c {
 	case "build":
 		Build(build, config)

--- a/main_test.go
+++ b/main_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ func testMain(t *testing.T, _ spec.G, it spec.S) {
 		detectFunc        libcnb.DetectFunc
 		environmentWriter *mocks.EnvironmentWriter
 		exitHandler       *mocks.ExitHandler
+		generateFunc      libcnb.GenerateFunc
 		layersPath        string
 		platformPath      string
 		tomlWriter        *mocks.TOMLWriter
@@ -109,6 +110,10 @@ test-key = "test-value"
 
 		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
 			return libcnb.DetectResult{}, nil
+		}
+
+		generateFunc = func(libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+			return libcnb.GenerateResult{}, nil
 		}
 
 		environmentWriter = &mocks.EnvironmentWriter{}
@@ -181,7 +186,7 @@ test-key = "test-value"
 	})
 
 	it("encounters the wrong number of arguments", func() {
-		libcnb.Main(detectFunc, buildFunc,
+		libcnb.Main(detectFunc, buildFunc, generateFunc,
 			libcnb.WithArguments([]string{}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
@@ -193,7 +198,7 @@ test-key = "test-value"
 	it("calls builder for build command", func() {
 		commandPath := filepath.Join("bin", "build")
 
-		libcnb.Main(detectFunc, buildFunc,
+		libcnb.Main(detectFunc, buildFunc, generateFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
@@ -208,11 +213,26 @@ test-key = "test-value"
 		}
 		commandPath := filepath.Join("bin", "detect")
 
-		libcnb.Main(detectFunc, buildFunc,
+		libcnb.Main(detectFunc, buildFunc, generateFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
 		)
+
+	})
+
+	it("calls generator for generate command", func() {
+		generateFunc = func(libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+			return libcnb.GenerateResult{}, nil
+		}
+		commandPath := filepath.Join("bin", "generate")
+
+		libcnb.Main(nil, nil, generateFunc,
+			libcnb.WithArguments([]string{commandPath}),
+			libcnb.WithExitHandler(exitHandler),
+			libcnb.WithLogger(log.NewDiscard()),
+		)
+
 	})
 
 	it("calls exitHandler.Pass() on detection pass", func() {
@@ -221,7 +241,7 @@ test-key = "test-value"
 		}
 		commandPath := filepath.Join("bin", "detect")
 
-		libcnb.Main(detectFunc, buildFunc,
+		libcnb.Main(detectFunc, buildFunc, generateFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
@@ -236,7 +256,7 @@ test-key = "test-value"
 		}
 		commandPath := filepath.Join("bin", "detect")
 
-		libcnb.Main(detectFunc, buildFunc,
+		libcnb.Main(detectFunc, buildFunc, generateFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
@@ -248,7 +268,7 @@ test-key = "test-value"
 	it("encounters an unknown command", func() {
 		commandPath := filepath.Join("bin", "test-command")
 
-		libcnb.Main(detectFunc, buildFunc,
+		libcnb.Main(detectFunc, buildFunc, generateFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),

--- a/main_test.go
+++ b/main_test.go
@@ -186,7 +186,7 @@ test-key = "test-value"
 	})
 
 	it("encounters the wrong number of arguments", func() {
-		libcnb.Main(detectFunc, buildFunc, generateFunc,
+		libcnb.BuildpackMain(detectFunc, buildFunc,
 			libcnb.WithArguments([]string{}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
@@ -198,7 +198,7 @@ test-key = "test-value"
 	it("calls builder for build command", func() {
 		commandPath := filepath.Join("bin", "build")
 
-		libcnb.Main(detectFunc, buildFunc, generateFunc,
+		libcnb.BuildpackMain(detectFunc, buildFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
@@ -213,7 +213,7 @@ test-key = "test-value"
 		}
 		commandPath := filepath.Join("bin", "detect")
 
-		libcnb.Main(detectFunc, buildFunc, generateFunc,
+		libcnb.BuildpackMain(detectFunc, buildFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
@@ -227,7 +227,7 @@ test-key = "test-value"
 		}
 		commandPath := filepath.Join("bin", "generate")
 
-		libcnb.Main(nil, nil, generateFunc,
+		libcnb.ExtensionMain(nil, generateFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
@@ -241,7 +241,7 @@ test-key = "test-value"
 		}
 		commandPath := filepath.Join("bin", "detect")
 
-		libcnb.Main(detectFunc, buildFunc, generateFunc,
+		libcnb.BuildpackMain(detectFunc, buildFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
@@ -256,7 +256,7 @@ test-key = "test-value"
 		}
 		commandPath := filepath.Join("bin", "detect")
 
-		libcnb.Main(detectFunc, buildFunc, generateFunc,
+		libcnb.BuildpackMain(detectFunc, buildFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
@@ -268,7 +268,7 @@ test-key = "test-value"
 	it("encounters an unknown command", func() {
 		commandPath := filepath.Join("bin", "test-command")
 
-		libcnb.Main(detectFunc, buildFunc, generateFunc,
+		libcnb.BuildpackMain(detectFunc, buildFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),

--- a/main_test.go
+++ b/main_test.go
@@ -218,7 +218,6 @@ test-key = "test-value"
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
 		)
-
 	})
 
 	it("calls generator for generate command", func() {
@@ -232,7 +231,6 @@ test-key = "test-value"
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
 		)
-
 	})
 
 	it("calls exitHandler.Pass() on detection pass", func() {

--- a/platform.go
+++ b/platform.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,11 +44,17 @@ const (
 	// EnvBuildpackDirectory is the name of the environment variable that contains the path to the buildpack
 	EnvBuildpackDirectory = "CNB_BUILDPACK_DIR"
 
+	// EnvExtensionDirectory is the name of the environment variable that contains the path to the extension
+	EnvExtensionDirectory = "CNB_EXTENSION_DIR"
+
 	// EnvVcapServices is the name of the environment variable that contains the bindings in cloudfoundry
 	EnvVcapServices = "VCAP_SERVICES"
 
 	// EnvLayersDirectory is the name of the environment variable that contains the root path to all buildpack layers
 	EnvLayersDirectory = "CNB_LAYERS_DIR"
+
+	// EnvOutputDirectory is the name of the environment variable that contains the path to the output directory
+	EnvOutputDirectory = "CNB_OUTPUT_DIR"
 
 	// EnvPlatformDirectory is the name of the environment variable that contains the path to the platform directory
 	EnvPlatformDirectory = "CNB_PLATFORM_DIR"


### PR DESCRIPTION
This PR contains a first pass at adding support for Extensions (https://github.com/buildpacks/spec/blob/main/image_extension.md) to libcnb.

This introduces 
 - extension.go with Extension/ExtensionInfo structs that represent extension.toml content
 - generate.go/generate_test.go to represent the generate lifecycle invocation
 - example_generate_test.go as an example of GenerateFunc
 - **Renames Main to BuildpackMain and introduces ExtensionMain** (breaking change)
 - Adds extension env var constants to platform.go
 
 This PR does **NOT** address
 - the current min/max supported buildpack API level.. (this does likely need updating to encompass extensions)
   - (these are currently defined in build.go but should probably move to a common location for build/generate)
 - any sort of utility function for implementors of extensions to assist in writing Dockerfile content
 - any commonality between BuildpackInfo and ExtensionInfo 
 
 This PR will go a long way towards resolving Issue #230 
 
 Raising this at this stage mostly for comments, happy to address additional items from above in this PR if the consensus is that makes sense =)

