### PR TITLE
Distinguish provider and type when reading binding from VCAP_SERVICES (1.x BACKPORT)

### DIFF
--- a/platform.go
+++ b/platform.go
@@ -119,6 +119,7 @@ func NewBindingFromPath(path string) (Binding, error) {
 
 type vcapServicesBinding struct {
 	Name        string            `json:"name"`
+	Label       string            `json:"label"`
 	Credentials map[string]string `json:"credentials"`
 }
 
@@ -132,12 +133,13 @@ func NewBindingsFromVcapServicesEnv(content string) (Bindings, error) {
 	}
 
 	bindings := Bindings{}
-	for t, bArray := range contentTyped {
+	for p, bArray := range contentTyped {
 		for _, b := range bArray {
 			bindings = append(bindings, Binding{
-				Name:   b.Name,
-				Type:   t,
-				Secret: b.Credentials,
+				Name:     b.Name,
+				Type:     b.Label,
+				Provider: p,
+				Secret:   b.Credentials,
 			})
 		}
 	}

--- a/platform_test.go
+++ b/platform_test.go
@@ -53,7 +53,9 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 				Expect(bindings).To(HaveLen(2))
 
 				types := []string{bindings[0].Type, bindings[1].Type}
-				Expect(types).To(ContainElements("elephantsql", "sendgrid"))
+				Expect(types).To(ContainElements("elephantsql-type", "sendgrid-type"))
+				providers := []string{bindings[0].Provider, bindings[1].Provider}
+				Expect(providers).To(ContainElements("elephantsql-provider", "sendgrid-provider"))
 			})
 
 			it("creates empty bindings from empty VCAP_SERVICES", func() {
@@ -77,7 +79,7 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 
 				Expect(bindings).To(HaveLen(2))
 				types := []string{bindings[0].Type, bindings[1].Type}
-				Expect(types).To(ContainElements("elephantsql", "sendgrid"))
+				Expect(types).To(ContainElements("elephantsql-type", "sendgrid-type"))
 			})
 
 			it("creates empty bindings from empty VCAP_SERVICES", func() {

--- a/testdata/vcap_services.json
+++ b/testdata/vcap_services.json
@@ -1,12 +1,12 @@
 {
-    "elephantsql": [
+    "elephantsql-provider": [
       {
         "name": "elephantsql-binding-c6c60",
         "binding_guid": "44ceb72f-100b-4f50-87a2-7809c8b42b8d",
         "binding_name": "elephantsql-binding-c6c60",
         "instance_guid": "391308e8-8586-4c42-b464-c7831aa2ad22",
         "instance_name": "elephantsql-c6c60",
-        "label": "elephantsql",
+        "label": "elephantsql-type",
         "tags": [
           "postgres",
           "postgresql",
@@ -20,14 +20,14 @@
         "volume_mounts": []
       }
     ],
-    "sendgrid": [
+    "sendgrid-provider": [
       {
         "name": "mysendgrid",
         "binding_guid": "6533b1b6-7916-488d-b286-ca33d3fa0081",
         "binding_name": null,
         "instance_guid": "8c907d0f-ec0f-44e4-87cf-e23c9ba3925d",
         "instance_name": "mysendgrid",
-        "label": "sendgrid",
+        "label": "sendgrid-type",
         "tags": [
           "smtp"
         ],


### PR DESCRIPTION
Backport https://github.com/buildpacks/libcnb/pull/235 to the `release-1.x` branch