### PR TITLE
Ensure non-nil debugwriter for easier v2v migration

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -92,9 +92,8 @@ func (l PlainLogger) Debugf(format string, a ...interface{}) {
 func (l PlainLogger) DebugWriter() io.Writer {
 	if l.IsDebugEnabled() {
 		return l.debug
-	} else {
-		return io.Discard
 	}
+	return io.Discard
 }
 
 // IsDebugEnabled indicates whether debug logging is enabled.

--- a/log/logger.go
+++ b/log/logger.go
@@ -90,7 +90,11 @@ func (l PlainLogger) Debugf(format string, a ...interface{}) {
 
 // DebugWriter returns the configured debug writer.
 func (l PlainLogger) DebugWriter() io.Writer {
-	return l.debug
+	if l.IsDebugEnabled() {
+		return l.debug
+	} else {
+		return io.Discard
+	}
 }
 
 // IsDebugEnabled indicates whether debug logging is enabled.

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -18,6 +18,7 @@ package log_test
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"testing"
 
@@ -46,6 +47,14 @@ func testLogger(t *testing.T, context spec.G, it spec.S) {
 
 		it("does not configure debug", func() {
 			Expect(l.IsDebugEnabled()).To(BeFalse())
+		})
+
+		it("does not return nil debug writer", func() {
+			Expect(l.DebugWriter()).To(Not(BeNil()))
+		})
+
+		it("does not return non-discard writer", func() {
+			Expect(l.DebugWriter()).To(Equal(io.Discard))
 		})
 	})
 


### PR DESCRIPTION
Some testcases are driving code that uses logger.debugWriter() when debug has not been enabled, this currently leads to a nil writer being returning, which causes code panics within the debug calls. This is an indirect side effect of the choice to move from a struct in the v1 poet logger, to an interface within the v2 logger. Many testcases do not initialize a logger, and run without debug being set, and yet end up driving code that attempts to log debug messages. Mostly these are ok when logged via the log.Debug* methods, but if the writer is obtained directly then panics can occur when the nil is dereferenced.

Rather than chasing down every testcase individually, it seems safer to return a no-op writer when debug is disabled. 

Added two testcases to check new behavior.