### PR TITLE
Convert nested binding credentials to JSON

### DIFF
--- a/platform.go
+++ b/platform.go
@@ -118,9 +118,22 @@ func NewBindingFromPath(path string) (Binding, error) {
 }
 
 type vcapServicesBinding struct {
-	Name        string            `json:"name"`
-	Label       string            `json:"label"`
-	Credentials map[string]string `json:"credentials"`
+	Name        string                 `json:"name"`
+	Label       string                 `json:"label"`
+	Credentials map[string]interface{} `json:"credentials"`
+}
+
+func toJSONString(input interface{}) (string, error) {
+	switch in := input.(type) {
+	case string:
+		return in, nil
+	default:
+		jsonProperty, err := json.Marshal(in)
+		if err != nil {
+			return "", err
+		}
+		return string(jsonProperty), nil
+	}
 }
 
 // NewBindingsFromVcapServicesEnv creates a new instance from all the bindings given from the VCAP_SERVICES.
@@ -129,17 +142,24 @@ func NewBindingsFromVcapServicesEnv(content string) (Bindings, error) {
 
 	err := json.Unmarshal([]byte(content), &contentTyped)
 	if err != nil {
-		return Bindings{}, nil
+		return Bindings{}, err
 	}
 
 	bindings := Bindings{}
 	for p, bArray := range contentTyped {
 		for _, b := range bArray {
+			secret := map[string]string{}
+			for k, v := range b.Credentials {
+				secret[k], err = toJSONString(v)
+				if err != nil {
+					return nil, err
+				}
+			}
 			bindings = append(bindings, Binding{
 				Name:     b.Name,
 				Type:     b.Label,
 				Provider: p,
-				Secret:   b.Credentials,
+				Secret:   secret,
 			})
 		}
 	}

--- a/platform_test.go
+++ b/platform_test.go
@@ -50,12 +50,38 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 				bindings, err := libcnb.NewBindingsForBuild("")
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(bindings).To(HaveLen(2))
-
-				types := []string{bindings[0].Type, bindings[1].Type}
-				Expect(types).To(ContainElements("elephantsql-type", "sendgrid-type"))
-				providers := []string{bindings[0].Provider, bindings[1].Provider}
-				Expect(providers).To(ContainElements("elephantsql-provider", "sendgrid-provider"))
+				Expect(bindings).To(ConsistOf(libcnb.Bindings{
+					{
+						Name:     "elephantsql-binding-c6c60",
+						Type:     "elephantsql-type",
+						Provider: "elephantsql-provider",
+						Secret: map[string]string{
+							"bool": "true",
+							"int":  "1",
+							"uri":  "postgres://exampleuser:examplepass@postgres.example.com:5432/exampleuser",
+						},
+					},
+					{
+						Name:     "mysendgrid",
+						Type:     "sendgrid-type",
+						Provider: "sendgrid-provider",
+						Secret: map[string]string{
+							"username": "QvsXMbJ3rK",
+							"password": "HCHMOYluTv",
+							"hostname": "smtp.example.com",
+						},
+					},
+					{
+						Name:     "postgres",
+						Type:     "postgres",
+						Provider: "postgres",
+						Secret: map[string]string{
+							"urls":     "{\"example\":\"http://example.com\"}",
+							"username": "foo",
+							"password": "bar",
+						},
+					},
+				}))
 			})
 
 			it("creates empty bindings from empty VCAP_SERVICES", func() {
@@ -77,9 +103,9 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 				bindings, err := libcnb.NewBindingsForLaunch()
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(bindings).To(HaveLen(2))
-				types := []string{bindings[0].Type, bindings[1].Type}
-				Expect(types).To(ContainElements("elephantsql-type", "sendgrid-type"))
+				Expect(bindings).To(HaveLen(3))
+				types := []string{bindings[0].Type, bindings[1].Type, bindings[2].Type}
+				Expect(types).To(ContainElements("elephantsql-type", "sendgrid-type", "postgres"))
 			})
 
 			it("creates empty bindings from empty VCAP_SERVICES", func() {

--- a/testdata/vcap_services.json
+++ b/testdata/vcap_services.json
@@ -1,44 +1,68 @@
 {
-    "elephantsql-provider": [
-      {
-        "name": "elephantsql-binding-c6c60",
-        "binding_guid": "44ceb72f-100b-4f50-87a2-7809c8b42b8d",
-        "binding_name": "elephantsql-binding-c6c60",
-        "instance_guid": "391308e8-8586-4c42-b464-c7831aa2ad22",
-        "instance_name": "elephantsql-c6c60",
-        "label": "elephantsql-type",
-        "tags": [
-          "postgres",
-          "postgresql",
-          "relational"
-        ],
-        "plan": "turtle",
-        "credentials": {
-          "uri": "postgres://exampleuser:examplepass@postgres.example.com:5432/exampleuser"
-        },
-        "syslog_drain_url": null,
-        "volume_mounts": []
-      }
-    ],
-    "sendgrid-provider": [
-      {
-        "name": "mysendgrid",
-        "binding_guid": "6533b1b6-7916-488d-b286-ca33d3fa0081",
-        "binding_name": null,
-        "instance_guid": "8c907d0f-ec0f-44e4-87cf-e23c9ba3925d",
-        "instance_name": "mysendgrid",
-        "label": "sendgrid-type",
-        "tags": [
-          "smtp"
-        ],
-        "plan": "free",
-        "credentials": {
-          "hostname": "smtp.example.com",
-          "username": "QvsXMbJ3rK",
-          "password": "HCHMOYluTv"
-        },
-        "syslog_drain_url": null,
-        "volume_mounts": []
-      }
-    ]
+  "elephantsql-provider": [
+    {
+      "name": "elephantsql-binding-c6c60",
+      "binding_guid": "44ceb72f-100b-4f50-87a2-7809c8b42b8d",
+      "binding_name": "elephantsql-binding-c6c60",
+      "instance_guid": "391308e8-8586-4c42-b464-c7831aa2ad22",
+      "instance_name": "elephantsql-c6c60",
+      "label": "elephantsql-type",
+      "tags": [
+        "postgres",
+        "postgresql",
+        "relational"
+      ],
+      "plan": "turtle",
+      "credentials": {
+        "uri": "postgres://exampleuser:examplepass@postgres.example.com:5432/exampleuser",
+        "int": 1,
+        "bool": true
+      },
+      "syslog_drain_url": null,
+      "volume_mounts": []
+    }
+  ],
+  "sendgrid-provider": [
+    {
+      "name": "mysendgrid",
+      "binding_guid": "6533b1b6-7916-488d-b286-ca33d3fa0081",
+      "binding_name": null,
+      "instance_guid": "8c907d0f-ec0f-44e4-87cf-e23c9ba3925d",
+      "instance_name": "mysendgrid",
+      "label": "sendgrid-type",
+      "tags": [
+        "smtp"
+      ],
+      "plan": "free",
+      "credentials": {
+        "hostname": "smtp.example.com",
+        "username": "QvsXMbJ3rK",
+        "password": "HCHMOYluTv"
+      },
+      "syslog_drain_url": null,
+      "volume_mounts": []
+    }
+  ],
+  "postgres": [
+    {
+      "name": "postgres",
+      "label": "postgres",
+      "plan": "default",
+      "tags": [
+        "postgres"
+      ],
+      "binding_guid": "6533b1b6-7916-488d-b286-ca33d3fa0081",
+      "binding_name": null,
+      "instance_guid": "8c907d0f-ec0f-44e4-87cf-e23c9ba3925d",
+      "credentials": {
+        "username": "foo",
+        "password": "bar",
+        "urls": {
+          "example": "http://example.com"
+        }
+      },
+      "syslog_drain_url": null,
+      "volume_mounts": []
+    }
+  ]
 }


### PR DESCRIPTION
Downport of #256 

Fixes https://github.com/buildpacks/libcnb/issues/254.

Fix swallowing the parsing error and marshal properties to JSON if they are not a string.