### PR TITLE
Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,22 @@ updates:
     - package-ecosystem: gomod
       directory: /
       schedule:
-        interval: daily
+        interval: weekly
+      groups:
+        # Group all minor/patch go dependencies into a single PR.
+        go-dependencies:
+          update-types:
+            - "minor"
+            - "patch"
       ignore:
         - dependency-name: github.com/onsi/gomega
+      labels:
+        - semver:patch
+        - type:dependency-upgrade
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+        interval: weekly
       labels:
         - semver:patch
         - type:dependency-upgrade


### PR DESCRIPTION
Dependabot updates for GitHub Actions are now enabled, for parity with the other repos.

In addition, Go minor/patch dependencies will now be grouped, using the new Dependabot grouping feature:
https://github.blog/changelog/2023-08-17-grouped-version-updates-by-semantic-version-level-for-dependabot/

Major updates, as well as security updates will still be opened as separate PRs. I've not grouped GitHub Actions update PRs, since the volume is typically much lower for those.

Lastly, the schedule has been changed from daily to weekly.

This reduces project maintenance toil (no more having to manually create combined update PRs), plus makes it less painful for contributors to subscribe to repository notifications (currently there is a lot of noise from Dependabot PRs being opened/auto-rebased etc).