### PR TITLE
align toml tag of `working-dir` with spec

### DIFF
--- a/application.go
+++ b/application.go
@@ -49,7 +49,7 @@ type Process struct {
 	Direct bool `toml:"direct,omitempty"`
 
 	// WorkingDirectory is a directory to execute the command in, removes the need to use a shell environment to CD into working directory
-	WorkingDirectory string `toml:"working-directory,omitempty"`
+	WorkingDirectory string `toml:"working-dir,omitempty"`
 
 	// Default can be set to true to indicate that the process
 	// type being defined should be the default process type for the app image.


### PR DESCRIPTION
See https://github.com/buildpacks/spec/blob/buildpack/v0.10/buildpack.md#launchtoml-toml

See also: same PR but for `2.x` release #269 