### PR TITLE
align toml tag of `working-dir` with spec

### DIFF
--- a/process.go
+++ b/process.go
@@ -28,7 +28,7 @@ type Process struct {
 	Arguments []string `toml:"args"`
 
 	// WorkingDirectory is a directory to execute the command in, removes the need to use a shell environment to CD into working directory
-	WorkingDirectory string `toml:"working-directory,omitempty"`
+	WorkingDirectory string `toml:"working-dir,omitempty"`
 
 	// Default can be set to true to indicate that the process
 	// type being defined should be the default process type for the app image.


### PR DESCRIPTION
See https://github.com/buildpacks/spec/blob/buildpack/v0.10/buildpack.md#launchtoml-toml

See also: same PR but for `1.x` release #268