### PR TITLE
Do not enforce presence of CNB_STACK_ID

### DIFF
--- a/build.go
+++ b/build.go
@@ -226,10 +226,10 @@ func Build(build BuildFunc, config Config) {
 	config.logger.Debugf("Buildpack Plan: %+v", ctx.Plan)
 
 	if ctx.StackID, ok = os.LookupEnv(EnvStackID); !ok {
-		config.exitHandler.Error(fmt.Errorf("CNB_STACK_ID not set"))
-		return
+		config.logger.Debug("CNB_STACK_ID not set")
+	} else {
+		config.logger.Debugf("Stack: %s", ctx.StackID)
 	}
-	config.logger.Debugf("Stack: %s", ctx.StackID)
 
 	result, err := build(ctx)
 	if err != nil {

--- a/build_test.go
+++ b/build_test.go
@@ -253,19 +253,6 @@ version = "1.1.1"
 		}
 	})
 
-	it("doesn't receive CNB_STACK_ID", func() {
-		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
-
-		libcnb.Build(buildFunc,
-			libcnb.NewConfig(
-				libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
-				libcnb.WithExitHandler(exitHandler),
-				libcnb.WithLogger(log.NewDiscard())),
-		)
-
-		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("CNB_STACK_ID not set"))
-	})
-
 	context("has a build environment", func() {
 		var ctx libcnb.BuildContext
 

--- a/detect.go
+++ b/detect.go
@@ -185,10 +185,10 @@ func Detect(detect DetectFunc, config Config) {
 	config.logger.Debugf("Platform Environment: %s", ctx.Platform.Environment)
 
 	if ctx.StackID, ok = os.LookupEnv(EnvStackID); !ok {
-		config.exitHandler.Error(fmt.Errorf("CNB_STACK_ID not set"))
-		return
+		config.logger.Debug("CNB_STACK_ID not set")
+	} else {
+		config.logger.Debugf("Stack: %s", ctx.StackID)
 	}
-	config.logger.Debugf("Stack: %s", ctx.StackID)
 
 	result, err := detect(ctx)
 	if err != nil {

--- a/detect_test.go
+++ b/detect_test.go
@@ -175,19 +175,6 @@ version = "1.1.1"
 		})
 	})
 
-	it("doesn't receive CNB_STACK_ID", func() {
-		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
-
-		libcnb.Detect(detectFunc,
-			libcnb.NewConfig(
-				libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
-				libcnb.WithExitHandler(exitHandler),
-				libcnb.WithLogger(log.NewDiscard())),
-		)
-
-		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("CNB_STACK_ID not set"))
-	})
-
 	context("errors if required env vars are not set", func() {
 		for _, e := range []string{"CNB_PLATFORM_DIR", "CNB_BUILD_PLAN_PATH"} {
 			// We need to do this assignment because of the way that spec binds variables

--- a/generate.go
+++ b/generate.go
@@ -179,10 +179,10 @@ func Generate(generate GenerateFunc, config Config) {
 	config.logger.Debugf("Buildpack Plan: %+v", ctx.Plan)
 
 	if ctx.StackID, ok = os.LookupEnv(EnvStackID); !ok {
-		config.exitHandler.Error(fmt.Errorf("CNB_STACK_ID not set"))
-		return
+		config.logger.Debug("CNB_STACK_ID not set")
+	} else {
+		config.logger.Debugf("Stack: %s", ctx.StackID)
 	}
-	config.logger.Debugf("Stack: %s", ctx.StackID)
 
 	result, err := generate(ctx)
 	if err != nil {

--- a/generate_test.go
+++ b/generate_test.go
@@ -235,19 +235,6 @@ version = "1.1.1"
 		}
 	})
 
-	it("doesn't receive CNB_STACK_ID", func() {
-		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
-
-		libcnb.Generate(generateFunc,
-			libcnb.NewConfig(
-				libcnb.WithArguments([]string{commandPath, outputPath, platformPath, buildpackPlanPath}),
-				libcnb.WithExitHandler(exitHandler),
-				libcnb.WithLogger(log.NewDiscard())),
-		)
-
-		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("CNB_STACK_ID not set"))
-	})
-
 	context("has a build environment", func() {
 		var ctx libcnb.GenerateContext
 


### PR DESCRIPTION
If`CNB_STACK_ID` is not present, the buildpacks should not just fail.

related rfc: https://github.com/buildpacks/rfcs/blob/main/text/0096-remove-stacks-mixins.md
first step for fixing https://github.com/paketo-buildpacks/libpak/issues/329

This also aligns the behavior with `packit`, so that all `paketo` buildpacks behave similar.
