### PR TITLE
Do not enforce presence of CNB_STACK_ID

### DIFF
--- a/build.go
+++ b/build.go
@@ -249,10 +249,10 @@ func Build(builder Builder, options ...Option) {
 	logger.Debugf("Buildpack Plan: %+v", ctx.Plan)
 
 	if ctx.StackID, ok = os.LookupEnv("CNB_STACK_ID"); !ok {
-		config.exitHandler.Error(fmt.Errorf("CNB_STACK_ID not set"))
-		return
+		logger.Debug("CNB_STACK_ID not set")
+	} else {
+		logger.Debugf("Stack: %s", ctx.StackID)
 	}
-	logger.Debugf("Stack: %s", ctx.StackID)
 
 	result, err := builder.Build(ctx)
 	if err != nil {

--- a/build_test.go
+++ b/build_test.go
@@ -256,19 +256,6 @@ version = "1.1.1"
 		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("expected 3 arguments and received 0"))
 	})
 
-	it("doesn't receive CNB_STACK_ID", func() {
-		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
-		builder.On("Build", mock.Anything).Return(libcnb.NewBuildResult(), nil)
-
-		libcnb.Build(builder,
-			libcnb.WithBOMLabel(true),
-			libcnb.WithArguments([]string{commandPath, layersPath, platformPath, buildpackPlanPath}),
-			libcnb.WithExitHandler(exitHandler),
-		)
-
-		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("CNB_STACK_ID not set"))
-	})
-
 	context("when BP API >= 0.8", func() {
 		it.Before(func() {
 			Expect(os.WriteFile(filepath.Join(buildpackPath, "buildpack.toml"),

--- a/detect.go
+++ b/detect.go
@@ -163,10 +163,10 @@ func Detect(detector Detector, options ...Option) {
 	logger.Debugf("Platform Environment: %s", ctx.Platform.Environment)
 
 	if ctx.StackID, ok = os.LookupEnv("CNB_STACK_ID"); !ok {
-		config.exitHandler.Error(fmt.Errorf("CNB_STACK_ID not set"))
-		return
+		logger.Debug("CNB_STACK_ID not set")
+	} else {
+		logger.Debugf("Stack: %s", ctx.StackID)
 	}
-	logger.Debugf("Stack: %s", ctx.StackID)
 
 	result, err := detector.Detect(ctx)
 	if err != nil {

--- a/detect_test.go
+++ b/detect_test.go
@@ -174,18 +174,6 @@ version = "1.1.1"
 		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("expected 2 arguments and received 0"))
 	})
 
-	it("doesn't receive CNB_STACK_ID", func() {
-		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
-		detector.On("Detect", mock.Anything).Return(libcnb.DetectResult{}, nil)
-
-		libcnb.Detect(detector,
-			libcnb.WithArguments([]string{commandPath, platformPath, buildPlanPath}),
-			libcnb.WithExitHandler(exitHandler),
-		)
-
-		Expect(exitHandler.Calls[0].Arguments.Get(0)).To(MatchError("CNB_STACK_ID not set"))
-	})
-
 	context("errors if required env vars are not set for buildpack API >=0.8", func() {
 		for _, e := range []string{"CNB_PLATFORM_DIR", "CNB_BUILD_PLAN_PATH"} {
 			// We need to do this assignment because of the way that spec binds variables


### PR DESCRIPTION
If`CNB_STACK_ID` is not present, the buildpacks should not just fail.

related rfc: https://github.com/buildpacks/rfcs/blob/main/text/0096-remove-stacks-mixins.md
first step for fixing https://github.com/paketo-buildpacks/libpak/issues/329

This also aligns the behavior with `packit`, so that all `paketo` buildpacks behave similar.

Downport of https://github.com/buildpacks/libcnb/pull/283
