### PR TITLE
Make buildpack API generic

### DIFF
--- a/build_plan.go
+++ b/build_plan.go
@@ -23,28 +23,28 @@ type BuildPlanProvide struct {
 }
 
 // BuildPlanRequire represents a dependency required by a buildpack.
-type BuildPlanRequire struct {
+type BuildPlanRequire[PL any] struct {
 	// Name is the name of the dependency.
 	Name string `toml:"name"`
 
 	// Metadata is the metadata for the dependency. Optional.
-	Metadata map[string]interface{} `toml:"metadata,omitempty"`
+	Metadata map[string]PL `toml:"metadata,omitempty"`
 }
 
 // BuildPlan represents the provisions and requirements of a buildpack during detection.
-type BuildPlan struct {
+type BuildPlan[PL any] struct {
 	// Provides is the dependencies provided by the buildpack.
 	Provides []BuildPlanProvide `toml:"provides,omitempty"`
 
 	// Requires is the dependencies required by the buildpack.
-	Requires []BuildPlanRequire `toml:"requires,omitempty"`
+	Requires []BuildPlanRequire[PL] `toml:"requires,omitempty"`
 }
 
 // BuildPlans represents a collection of build plans produced by a buildpack during detection.
-type BuildPlans struct {
+type BuildPlans[PL any] struct {
 	// BuildPlan is the first build plan.
-	BuildPlan
+	BuildPlan[PL]
 
 	// Or is the collection of other build plans.
-	Or []BuildPlan `toml:"or,omitempty"`
+	Or []BuildPlan[PL] `toml:"or,omitempty"`
 }

--- a/buildpack.go
+++ b/buildpack.go
@@ -112,7 +112,7 @@ type Target struct {
 }
 
 // Buildpack is the contents of the buildpack.toml file.
-type Buildpack struct {
+type Buildpack[BM any] struct {
 	// API is the api version expected by the buildpack.
 	API string `toml:"api"`
 
@@ -129,5 +129,5 @@ type Buildpack struct {
 	Targets []Target `toml:"targets"`
 
 	// Metadata is arbitrary metadata attached to the buildpack.
-	Metadata map[string]interface{} `toml:"metadata"`
+	Metadata map[string]BM `toml:"metadata"`
 }

--- a/buildpack_plan.go
+++ b/buildpack_plan.go
@@ -17,19 +17,19 @@
 package libcnb
 
 // BuildpackPlan represents a buildpack plan.
-type BuildpackPlan struct {
+type BuildpackPlan[PL any] struct {
 
 	// Entries represents all the buildpack plan entries.
-	Entries []BuildpackPlanEntry `toml:"entries,omitempty"`
+	Entries []BuildpackPlanEntry[PL] `toml:"entries,omitempty"`
 }
 
 // BuildpackPlanEntry represents an entry in the buildpack plan.
-type BuildpackPlanEntry struct {
+type BuildpackPlanEntry[PL any] struct {
 	// Name represents the name of the entry.
 	Name string `toml:"name"`
 
 	// Metadata is the metadata of the entry.  Optional.
-	Metadata map[string]interface{} `toml:"metadata,omitempty"`
+	Metadata map[string]PL `toml:"metadata,omitempty"`
 }
 
 // UnmetPlanEntry denotes an unmet buildpack plan entry. When a buildpack returns an UnmetPlanEntry

--- a/buildpack_test.go
+++ b/buildpack_test.go
@@ -34,7 +34,7 @@ func testBuildpackTOML(t *testing.T, _ spec.G, it spec.S) {
 	)
 
 	it("does not serialize the Path field", func() {
-		bp := libcnb.Buildpack{
+		bp := libcnb.Buildpack[string]{
 			API: "0.8",
 			Info: libcnb.BuildpackInfo{
 				ID:   "test-buildpack/sample",

--- a/detect.go
+++ b/detect.go
@@ -30,17 +30,17 @@ import (
 )
 
 // DetectContext contains the inputs to detection.
-type DetectContext struct {
+type DetectContext[EM any, BM any] struct {
 
 	// ApplicationPath is the location of the application source code as provided by
 	// the lifecycle.
 	ApplicationPath string
 
 	// Buildpack is metadata about the buildpack from buildpack.toml (empty when processing an extension)
-	Buildpack Buildpack
+	Buildpack Buildpack[BM]
 
 	// Extension is metadata about the extension from extension.toml (empty when processing a buildpack)
-	Extension Extension
+	Extension Extension[EM]
 
 	// Logger is the way to write messages to the end user
 	Logger log.Logger
@@ -53,20 +53,20 @@ type DetectContext struct {
 }
 
 // DetectResult contains the results of detection.
-type DetectResult struct {
+type DetectResult[DPL any] struct {
 
 	// Pass indicates whether detection has passed.
 	Pass bool
 
 	// Plans are the build plans contributed by the buildpack.
-	Plans []BuildPlan
+	Plans []BuildPlan[DPL]
 }
 
 // DetectFunc takes a context and returns a result, performing buildpack detect behaviors.
-type DetectFunc func(context DetectContext) (DetectResult, error)
+type DetectFunc[DPL any, EM any, BM any] func(context DetectContext[EM, BM]) (DetectResult[DPL], error)
 
 // Detect is called by the main function of a buildpack, for detection.
-func Detect(detect DetectFunc, config Config) {
+func Detect[DPL any, EM any, BM any](detect DetectFunc[DPL, EM, BM], config Config) {
 	var (
 		err         error
 		file        string
@@ -75,7 +75,7 @@ func Detect(detect DetectFunc, config Config) {
 		path        string
 		destination interface{}
 	)
-	ctx := DetectContext{Logger: config.logger}
+	ctx := DetectContext[EM, BM]{Logger: config.logger}
 
 	var moduletype = "buildpack"
 	if config.extension {
@@ -203,7 +203,7 @@ func Detect(detect DetectFunc, config Config) {
 	}
 
 	if len(result.Plans) > 0 {
-		var plans BuildPlans
+		var plans BuildPlans[DPL]
 		if len(result.Plans) > 0 {
 			plans.BuildPlan = result.Plans[0]
 		}

--- a/examples/generate_test.go
+++ b/examples/generate_test.go
@@ -12,7 +12,7 @@ type Generator struct {
 	Logger log.Logger
 }
 
-func (Generator) Generate(context libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+func (Generator) Generate(context libcnb.GenerateContext[string, string]) (libcnb.GenerateResult, error) {
 	// here you can read the context.ApplicationPath folder
 	// and create run.Dockerfile and build.Dockerfile in the context.OutputPath folder
 	// and read metadata from the context.Extension struct
@@ -26,5 +26,5 @@ func (Generator) Generate(context libcnb.GenerateContext) (libcnb.GenerateResult
 
 func ExampleGenerate() {
 	generator := Generator{log.New(os.Stdout)}
-	libcnb.ExtensionMain(nil, generator.Generate)
+	libcnb.ExtensionMain[string, string, string, string, string, string](nil, generator.Generate)
 }

--- a/extension.go
+++ b/extension.go
@@ -41,7 +41,7 @@ type ExtensionInfo struct {
 }
 
 // Extension is the contents of the extension.toml file.
-type Extension struct {
+type Extension[EM any] struct {
 	// API is the api version expected by the extension.
 	API string `toml:"api"`
 
@@ -55,5 +55,5 @@ type Extension struct {
 	Targets []Target `toml:"targets"`
 
 	// Metadata is arbitrary metadata attached to the extension.
-	Metadata map[string]interface{} `toml:"metadata"`
+	Metadata map[string]EM `toml:"metadata"`
 }

--- a/extension_test.go
+++ b/extension_test.go
@@ -34,7 +34,7 @@ func testExtensionTOML(t *testing.T, _ spec.G, it spec.S) {
 	)
 
 	it("does not serialize the Path field", func() {
-		extn := libcnb.Extension{
+		extn := libcnb.Extension[string]{
 			API: "0.8",
 			Info: libcnb.ExtensionInfo{
 				ID:   "test-buildpack/sample",

--- a/generate.go
+++ b/generate.go
@@ -30,13 +30,13 @@ import (
 )
 
 // GenerateContext contains the inputs to generate.
-type GenerateContext struct {
+type GenerateContext[PL any, EM any] struct {
 	// ApplicationPath is the location of the application source code as provided by
 	// the lifecycle.
 	ApplicationPath string
 
 	// Extension is metadata about the extension, from extension.toml.
-	Extension Extension
+	Extension Extension[EM]
 
 	// OutputDirectory is the location Dockerfiles should be written to.
 	OutputDirectory string
@@ -45,7 +45,7 @@ type GenerateContext struct {
 	Logger log.Logger
 
 	// Plan is the buildpack plan provided to the buildpack.
-	Plan BuildpackPlan
+	Plan BuildpackPlan[PL]
 
 	// Platform is the contents of the platform.
 	Platform Platform
@@ -100,16 +100,16 @@ func (b GenerateResult) String() string {
 }
 
 // GenerateFunc takes a context and returns a result, performing extension generate behaviors.
-type GenerateFunc func(context GenerateContext) (GenerateResult, error)
+type GenerateFunc[PL any, EM any] func(context GenerateContext[PL, EM]) (GenerateResult, error)
 
 // Generate is called by the main function of a extension, for generate phase
-func Generate(generate GenerateFunc, config Config) {
+func Generate[PL any, EM any](generate GenerateFunc[PL, EM], config Config) {
 	var (
 		err  error
 		file string
 		ok   bool
 	)
-	ctx := GenerateContext{Logger: config.logger}
+	ctx := GenerateContext[PL, EM]{Logger: config.logger}
 
 	ctx.ApplicationPath, err = os.Getwd()
 	if err != nil {

--- a/generate_test.go
+++ b/generate_test.go
@@ -38,7 +38,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		generateFunc      libcnb.GenerateFunc
+		generateFunc      libcnb.GenerateFunc[string, string]
 		applicationPath   string
 		extensionPath     string
 		outputPath        string
@@ -55,7 +55,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		generateFunc = func(libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+		generateFunc = func(libcnb.GenerateContext[string, string]) (libcnb.GenerateResult, error) {
 			return libcnb.NewGenerateResult(), nil
 		}
 
@@ -248,7 +248,7 @@ version = "1.1.1"
 	})
 
 	context("has a build environment", func() {
-		var ctx libcnb.GenerateContext
+		var ctx libcnb.GenerateContext[string, string]
 
 		it.Before(func() {
 			Expect(os.WriteFile(filepath.Join(extensionPath, "extension.toml"),
@@ -263,7 +263,7 @@ version = "1.1.1"
 				0600),
 			).To(Succeed())
 
-			generateFunc = func(context libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+			generateFunc = func(context libcnb.GenerateContext[string, string]) (libcnb.GenerateResult, error) {
 				ctx = context
 				return libcnb.NewGenerateResult(), nil
 			}
@@ -275,7 +275,7 @@ version = "1.1.1"
 					libcnb.WithArguments([]string{commandPath})),
 			)
 			Expect(ctx.ApplicationPath).To(Equal(applicationPath))
-			Expect(ctx.Extension).To(Equal(libcnb.Extension{
+			Expect(ctx.Extension).To(Equal(libcnb.Extension[string]{
 				API: "0.8",
 				Info: libcnb.ExtensionInfo{
 					ID:      "test-id",
@@ -285,11 +285,11 @@ version = "1.1.1"
 				Path: extensionPath,
 			}))
 			Expect(ctx.OutputDirectory).To(Equal(outputPath))
-			Expect(ctx.Plan).To(Equal(libcnb.BuildpackPlan{
-				Entries: []libcnb.BuildpackPlanEntry{
+			Expect(ctx.Plan).To(Equal(libcnb.BuildpackPlan[string]{
+				Entries: []libcnb.BuildpackPlanEntry[string]{
 					{
 						Name: "test-name",
-						Metadata: map[string]interface{}{
+						Metadata: map[string]string{
 							"test-key": "test-value",
 						},
 					},
@@ -313,7 +313,7 @@ version = "1.1.1"
 	})
 
 	context("has a build environment specifying target metadata", func() {
-		var ctx libcnb.GenerateContext
+		var ctx libcnb.GenerateContext[string, string]
 
 		it.Before(func() {
 			Expect(os.WriteFile(filepath.Join(extensionPath, "extension.toml"),
@@ -343,7 +343,7 @@ version = "1.1.1"
 					`), 0600),
 			).To(Succeed())
 
-			generateFunc = func(context libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+			generateFunc = func(context libcnb.GenerateContext[string, string]) (libcnb.GenerateResult, error) {
 				ctx = context
 				return libcnb.NewGenerateResult(), nil
 			}
@@ -389,7 +389,7 @@ version = "1.1.1"
 	})
 
 	it("handles error from GenerateFunc", func() {
-		generateFunc = func(libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+		generateFunc = func(libcnb.GenerateContext[string, string]) (libcnb.GenerateResult, error) {
 			return libcnb.NewGenerateResult(), errors.New("test-error")
 		}
 
@@ -404,7 +404,7 @@ version = "1.1.1"
 	})
 
 	it("writes Dockerfiles", func() {
-		generateFunc = func(_ libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+		generateFunc = func(_ libcnb.GenerateContext[string, string]) (libcnb.GenerateResult, error) {
 			result := libcnb.NewGenerateResult()
 			result.BuildDockerfile = []byte(`FROM foo:latest`)
 			result.RunDockerfile = []byte(`FROM bar:latest`)
@@ -423,7 +423,7 @@ version = "1.1.1"
 	})
 
 	it("writes extend-config.toml", func() {
-		generateFunc = func(_ libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+		generateFunc = func(_ libcnb.GenerateContext[string, string]) (libcnb.GenerateResult, error) {
 			result := libcnb.NewGenerateResult()
 			result.Config = &libcnb.ExtendConfig{
 				Build: libcnb.BuildConfig{

--- a/layer_test.go
+++ b/layer_test.go
@@ -31,7 +31,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		layers libcnb.Layers
+		layers libcnb.Layers[string]
 		path   string
 	)
 
@@ -53,15 +53,15 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	context("Reset", func() {
-		var layer libcnb.Layer
+		var layer libcnb.Layer[string]
 
 		it.Before(func() {
-			layers = libcnb.Layers{Path: t.TempDir()}
+			layers = libcnb.Layers[string]{Path: t.TempDir()}
 		})
 
 		context("when there is no previous build", func() {
 			it.Before(func() {
-				layer = libcnb.Layer{
+				layer = libcnb.Layer[string]{
 					Name: "test-name",
 					Path: filepath.Join(layers.Path, "test-name"),
 					LayerTypes: libcnb.LayerTypes{
@@ -77,7 +77,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 				layer, err = layer.Reset()
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(layer).To(Equal(libcnb.Layer{
+				Expect(layer).To(Equal(libcnb.Layer[string]{
 					Name: "test-name",
 					Path: filepath.Join(layers.Path, "test-name"),
 					LayerTypes: libcnb.LayerTypes{
@@ -120,7 +120,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 				err = os.WriteFile(filepath.Join(launchEnvDir, "APPEND_VAR.delim"), []byte("!"), 0600)
 				Expect(err).NotTo(HaveOccurred())
 
-				layer = libcnb.Layer{
+				layer = libcnb.Layer[string]{
 					Name: "test-name",
 					Path: filepath.Join(layers.Path, "test-name"),
 					LayerTypes: libcnb.LayerTypes{
@@ -138,7 +138,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 						"APPEND_VAR.append": "append-value",
 						"APPEND_VAR.delim":  "!",
 					},
-					Metadata: map[string]interface{}{
+					Metadata: map[string]string{
 						"some-key": "some-value",
 					},
 				}
@@ -149,7 +149,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 					layer, err := layer.Reset()
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(layer).To(Equal(libcnb.Layer{
+					Expect(layer).To(Equal(libcnb.Layer[string]{
 						Name: "test-name",
 						Path: filepath.Join(layers.Path, "test-name"),
 						LayerTypes: libcnb.LayerTypes{
@@ -182,7 +182,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("return an error", func() {
-				layer := libcnb.Layer{
+				layer := libcnb.Layer[string]{
 					Name: "some-layer",
 					Path: filepath.Join(layers.Path, "some-layer"),
 				}
@@ -200,7 +200,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			path, err = os.MkdirTemp("", "layers")
 			Expect(err).NotTo(HaveOccurred())
 
-			layers = libcnb.Layers{Path: path}
+			layers = libcnb.Layers[string]{Path: path}
 		})
 
 		it.After(func() {
@@ -269,7 +269,7 @@ test-key = "test-value"
 			l, err := layers.Layer("test-name")
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(l.Metadata).To(Equal(map[string]interface{}{"test-key": "test-value"}))
+			Expect(l.Metadata).To(Equal(map[string]string{"test-key": "test-value"}))
 			Expect(l.Launch).To(BeTrue())
 			Expect(l.Build).To(BeFalse())
 		})
@@ -292,7 +292,7 @@ test-key = "test-value"
 			l, err := layers.Layer("test-name")
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(l.Metadata).To(Equal(map[string]interface{}{"test-key": "test-value"}))
+			Expect(l.Metadata).To(Equal(map[string]string{"test-key": "test-value"}))
 			Expect(l.Launch).To(BeFalse())
 			Expect(l.Build).To(BeFalse())
 			Expect(l.Cache).To(BeFalse())

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 )
 
-func main(detect DetectFunc, build BuildFunc, generate GenerateFunc, options ...Option) {
+func main[DPL any, BPL any, PM any, LM any, EM any, BM any](detect DetectFunc[DPL, EM, BM], build BuildFunc[BPL, PM, LM, BM], generate GenerateFunc[BPL, EM], options ...Option) {
 	config := NewConfig(options...)
 
 	if len(config.arguments) == 0 {
@@ -45,11 +45,11 @@ func main(detect DetectFunc, build BuildFunc, generate GenerateFunc, options ...
 }
 
 // BuildpackMain is called by the main function of a buildpack, encapsulating both detection and build in the same binary.
-func BuildpackMain(detect DetectFunc, build BuildFunc, options ...Option) {
+func BuildpackMain[DPL any, BPL any, PM any, LM any, EM any, BM any](detect DetectFunc[DPL, EM, BM], build BuildFunc[BPL, PM, LM, BM], options ...Option) {
 	main(detect, build, nil, options...)
 }
 
 // ExtensionMain is called by the main function of a extension, encapsulating both detection and generation in the same binary.
-func ExtensionMain(detect DetectFunc, generate GenerateFunc, options ...Option) {
-	main(detect, nil, generate, options...)
+func ExtensionMain[DPL any, BPL any, PM any, LM any, EM any, BM any](detect DetectFunc[DPL, EM, BM], generate GenerateFunc[BPL, EM], options ...Option) {
+	main(detect, EmptyBuildFunc[BPL, PM, LM], generate, options...)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -35,13 +35,13 @@ func testMain(t *testing.T, _ spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		applicationPath   string
-		buildFunc         libcnb.BuildFunc
+		buildFunc         libcnb.BuildFunc[string, string, string, string]
 		buildpackPath     string
 		buildpackPlanPath string
-		detectFunc        libcnb.DetectFunc
+		detectFunc        libcnb.DetectFunc[string, string, string]
 		environmentWriter *mocks.EnvironmentWriter
 		exitHandler       *mocks.ExitHandler
-		generateFunc      libcnb.GenerateFunc
+		generateFunc      libcnb.GenerateFunc[string, string]
 		layersPath        string
 		platformPath      string
 		tomlWriter        *mocks.TOMLWriter
@@ -57,9 +57,7 @@ func testMain(t *testing.T, _ spec.G, it spec.S) {
 		applicationPath, err = filepath.EvalSymlinks(applicationPath)
 		Expect(err).NotTo(HaveOccurred())
 
-		buildFunc = func(libcnb.BuildContext) (libcnb.BuildResult, error) {
-			return libcnb.NewBuildResult(), nil
-		}
+		buildFunc = libcnb.EmptyBuildFunc[string, string]
 
 		buildpackPath, err = os.MkdirTemp("", "main-buildpack-path")
 		Expect(err).NotTo(HaveOccurred())
@@ -107,11 +105,11 @@ test-key = "test-value"
 			0600),
 		).To(Succeed())
 
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
-			return libcnb.DetectResult{}, nil
+		detectFunc = func(libcnb.DetectContext[string, string]) (libcnb.DetectResult[string], error) {
+			return libcnb.DetectResult[string]{}, nil
 		}
 
-		generateFunc = func(libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+		generateFunc = func(libcnb.GenerateContext[string, string]) (libcnb.GenerateResult, error) {
 			return libcnb.GenerateResult{}, nil
 		}
 
@@ -207,8 +205,8 @@ test-key = "test-value"
 	})
 
 	it("calls detector for detect command", func() {
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
-			return libcnb.DetectResult{Pass: true}, nil
+		detectFunc = func(libcnb.DetectContext[string, string]) (libcnb.DetectResult[string], error) {
+			return libcnb.DetectResult[string]{Pass: true}, nil
 		}
 		commandPath := filepath.Join("bin", "detect")
 
@@ -220,12 +218,12 @@ test-key = "test-value"
 	})
 
 	it("calls generator for generate command", func() {
-		generateFunc = func(libcnb.GenerateContext) (libcnb.GenerateResult, error) {
+		generateFunc = func(libcnb.GenerateContext[string, string]) (libcnb.GenerateResult, error) {
 			return libcnb.GenerateResult{}, nil
 		}
 		commandPath := filepath.Join("bin", "generate")
 
-		libcnb.ExtensionMain(nil, generateFunc,
+		libcnb.ExtensionMain[string, string, string, string, string, string](nil, generateFunc,
 			libcnb.WithArguments([]string{commandPath}),
 			libcnb.WithExitHandler(exitHandler),
 			libcnb.WithLogger(log.NewDiscard()),
@@ -233,8 +231,8 @@ test-key = "test-value"
 	})
 
 	it("calls exitHandler.Pass() on detection pass", func() {
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
-			return libcnb.DetectResult{Pass: true}, nil
+		detectFunc = func(libcnb.DetectContext[string, string]) (libcnb.DetectResult[string], error) {
+			return libcnb.DetectResult[string]{Pass: true}, nil
 		}
 		commandPath := filepath.Join("bin", "detect")
 
@@ -248,8 +246,8 @@ test-key = "test-value"
 	})
 
 	it("calls exitHandler.Fail() on detection fail", func() {
-		detectFunc = func(libcnb.DetectContext) (libcnb.DetectResult, error) {
-			return libcnb.DetectResult{Pass: false}, nil
+		detectFunc = func(libcnb.DetectContext[string, string]) (libcnb.DetectResult[string], error) {
+			return libcnb.DetectResult[string]{Pass: false}, nil
 		}
 		commandPath := filepath.Join("bin", "detect")
 

--- a/store.go
+++ b/store.go
@@ -17,8 +17,8 @@
 package libcnb
 
 // Store represents the contents of store.toml
-type Store struct {
+type Store[PM any] struct {
 
 	// Metadata represents the persistent metadata.
-	Metadata map[string]interface{} `toml:"metadata"`
+	Metadata map[string]PM `toml:"metadata"`
 }


### PR DESCRIPTION
Instead of using `interface{}` for things like metadata, we can use generic types. The buildpack API doesn't care what's in those values, so it can just be an `any` type. This will allow buildpack authors to set the types they want to use and even use custom types for their metadata. Then when accessing the metadata in their buildpacks, no casting is required. This reduces the amount of code and makes the code less error prone.