### PR TITLE
Parse type field from VCAP_SERVICES credentials

### DIFF
--- a/platform.go
+++ b/platform.go
@@ -155,9 +155,15 @@ func NewBindingsFromVcapServicesEnv(content string) (Bindings, error) {
 					return nil, err
 				}
 			}
+
+			bindingType := b.Label
+			if value, ok := secret["type"]; ok {
+				bindingType = value
+			}
+
 			bindings = append(bindings, Binding{
 				Name:     b.Name,
-				Type:     b.Label,
+				Type:     bindingType,
 				Provider: p,
 				Secret:   secret,
 			})

--- a/platform_test.go
+++ b/platform_test.go
@@ -81,6 +81,16 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 							"password": "bar",
 						},
 					},
+					{
+						Name:     "my-custom-binding",
+						Type:     "custom-type",
+						Provider: "user-provided",
+						Secret: map[string]string{
+							"username": "foo",
+							"password": "bar",
+							"type":     "custom-type",
+						},
+					},
 				}))
 			})
 
@@ -103,7 +113,7 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 				bindings, err := libcnb.NewBindingsForLaunch()
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(bindings).To(HaveLen(3))
+				Expect(bindings).To(HaveLen(4))
 				types := []string{bindings[0].Type, bindings[1].Type, bindings[2].Type}
 				Expect(types).To(ContainElements("elephantsql-type", "sendgrid-type", "postgres"))
 			})

--- a/testdata/vcap_services.json
+++ b/testdata/vcap_services.json
@@ -64,5 +64,22 @@
       "syslog_drain_url": null,
       "volume_mounts": []
     }
+  ],
+  "user-provided": [
+    {
+      "name": "my-custom-binding",
+      "label": "user-provided",
+      "plan": "default",
+      "binding_guid": "6533b1b6-7916-488d-b286-ca33d3fa0082",
+      "binding_name": null,
+      "instance_guid": "8c907d0f-ec0f-44e4-87cf-e23c9ba3925f",
+      "credentials": {
+        "username": "foo",
+        "password": "bar",
+        "type": "custom-type"
+      },
+      "syslog_drain_url": null,
+      "volume_mounts": []
+    }
   ]
 }


### PR DESCRIPTION
- currently the VCAP_SERVICES parsing will use the label from the binding as the type. This is problematic because user-provided bindings will always have label 'user-proved' which prevents users from creating custom bindings that are of a known type