### PR TITLE
Enable VCAP_SERVICES_FILE_PATH file based bindings support

### DIFF
--- a/platform.go
+++ b/platform.go
@@ -49,6 +49,9 @@ const (
 
 	// EnvVcapServices is the name of the environment variable that contains the bindings in cloudfoundry
 	EnvVcapServices = "VCAP_SERVICES"
+	
+	// EnvVcapServicesFilePath is the name of the environment variable that contains the filepath bindings in cloudfoundry
+	EnvVcapServicesFilePath = "VCAP_SERVICES_FILE_PATH"
 
 	// EnvLayersDirectory is the name of the environment variable that contains the root path to all buildpack layers
 	EnvLayersDirectory = "CNB_LAYERS_DIR"
@@ -241,9 +244,19 @@ func NewBindingsFromVcapServicesEnv(content string) (Bindings, error) {
 	return bindings, nil
 }
 
+// NewBindingsFromVcapServicesFilePathEnv creates a new instance from all the bindings given from the VCAP_SERVICE_FILE_PATH file based location.
+func NewBindingsFromVcapServicesFilePathEnv(file string) (Bindings, error) {
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	
+	return NewBindingsFromVcapServicesEnv(string(content))
+}
+
 // NewBindings creates a new bindings from all the bindings at the path defined by $SERVICE_BINDING_ROOT.
 // If that isn't defined, bindings are read from <platform>/bindings.
-// If that isn't defined, bindings are read from $VCAP_SERVICES.
+// If that isn't defined, bindings are read from $VCAP_SERVICES or $VCAP_SERVICES_FILE_PATH.
 // If that isn't defined, the specified platform path will be used
 func NewBindings(platformDir string) (Bindings, error) {
 	if path, ok := os.LookupEnv(EnvServiceBindings); ok {
@@ -256,6 +269,10 @@ func NewBindings(platformDir string) (Bindings, error) {
 
 	if content, ok := os.LookupEnv(EnvVcapServices); ok {
 		return NewBindingsFromVcapServicesEnv(content)
+	}
+	
+	if file, ok := os.LookupEnv(EnvVcapServicesFilePath); ok {
+		return NewBindingsFromVcapServicesFilePathEnv(file)
 	}
 
 	return NewBindingsFromPath(filepath.Join(platformDir, "bindings"))

--- a/platform_test.go
+++ b/platform_test.go
@@ -98,6 +98,48 @@ func testPlatform(t *testing.T, context spec.G, it spec.S) {
 			Expect(bindings).To(HaveLen(0))
 		})
 	})
+	
+	context("Cloudfoundry VCAP_SERVICES_FILE_PATH", func() {
+		it("creates a bindings from VCAP_SERVICES_FILE_PATH", func() {
+			t.Setenv(libcnb.EnvVcapServicesFilePath, "testdata/vcap_services.json")
+
+			bindings, err := libcnb.NewBindings("")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(bindings).To(ConsistOf(libcnb.Bindings{
+				{
+					Name:     "elephantsql-binding-c6c60",
+					Type:     "elephantsql-type",
+					Provider: "elephantsql-provider",
+					Secret: map[string]string{
+						"bool": "true",
+						"int":  "1",
+						"uri":  "postgres://exampleuser:examplepass@postgres.example.com:5432/exampleuser",
+					},
+				},
+				{
+					Name:     "mysendgrid",
+					Type:     "sendgrid-type",
+					Provider: "sendgrid-provider",
+					Secret: map[string]string{
+						"username": "QvsXMbJ3rK",
+						"password": "HCHMOYluTv",
+						"hostname": "smtp.example.com",
+					},
+				},
+				{
+					Name:     "postgres",
+					Type:     "postgres",
+					Provider: "postgres",
+					Secret: map[string]string{
+						"urls":     "{\"example\":\"http://example.com\"}",
+						"username": "foo",
+						"password": "bar",
+					},
+				},
+			}))
+		})
+	})
 
 	context("Kubernetes Service Bindings", func() {
 		it.Before(func() {


### PR DESCRIPTION
The change is with regard to the [VCAP_SERVICES_FILE_PATH](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES-FILE-PATH) functionality introduced in CF in order to be able to store **VCAP_SERVICES** content in a file. 
The 130KB limitation for **VCAP_SERVICES** is insufficient for increasing amount of use cases, especially when having huge certificates content. This limit is increased to 1MB for **VCAP_SERVICES_FILE_PATH** content.